### PR TITLE
Discord PR 알림 추가

### DIFF
--- a/.github/workflows/discord-pr-notification.yaml
+++ b/.github/workflows/discord-pr-notification.yaml
@@ -1,0 +1,28 @@
+name: Discord PR Notification
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord Notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_MESSAGE: ${{ vars.DISCORD_MESSAGE }}
+        run: |
+          MESSAGE="${DISCORD_MESSAGE}"
+
+          # Expand supported placeholders
+          MESSAGE="${MESSAGE//\{pr_title\}/${{ github.event.pull_request.title }}}"
+          MESSAGE="${MESSAGE//\{pr_url\}/${{ github.event.pull_request.html_url }}}"
+          MESSAGE="${MESSAGE//\{pr_author\}/${{ github.event.pull_request.user.login }}}"
+          MESSAGE="${MESSAGE//\{base_branch\}/${{ github.event.pull_request.base.ref }}}"
+          MESSAGE="${MESSAGE//\{head_branch\}/${{ github.event.pull_request.head.ref }}}"
+
+          curl -s -o /dev/null -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -d "{\"content\": $(echo "$MESSAGE" | jq -Rs .)}" \
+            "$DISCORD_WEBHOOK_URL" | grep -q "^2" || exit 1


### PR DESCRIPTION
## 요약

PR 생성 시 Discord Webhook을 통해 연결된 채널에 PR 알림을 생성하는 CI 워크플로우를 추가했습니다.