### PR TITLE
api-types response schema 추가 및 backend 수정

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -10,6 +10,11 @@ import {
   VerifyMailRequestDtoSchema,
   CompleteSignupRequestDtoSchema,
   LoginRequestDtoSchema,
+  SendMailResponseDtoSchema,
+  VerifyMailResponseDtoSchema,
+  CompleteSignupResponseDtoSchema,
+  LoginResponseDtoSchema,
+  RefreshTokensResponseDtoSchema,
 } from "@mindseed/api-types";
 import type {
   SendMailRequestDto,
@@ -24,6 +29,7 @@ import type {
 } from "@mindseed/api-types";
 import { AuthService } from "./auth.service";
 import { ZodBody } from "src/common/pipes/zod-body.decorator";
+import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
 
 @Controller("/auth")
 export class AuthController {
@@ -31,6 +37,7 @@ export class AuthController {
 
   @Post("/send-mail")
   @HttpCode(HttpStatus.OK)
+  @ZodEncodeResponse(SendMailResponseDtoSchema)
   async sendMail(
     @ZodBody(SendMailRequestDtoSchema) body: SendMailRequestDto,
   ): Promise<SendMailSuccessResponseDto> {
@@ -40,6 +47,7 @@ export class AuthController {
 
   @Post("/verify-mail")
   @HttpCode(HttpStatus.OK)
+  @ZodEncodeResponse(VerifyMailResponseDtoSchema)
   async verifyMail(
     @ZodBody(VerifyMailRequestDtoSchema) body: VerifyMailRequestDto,
   ): Promise<VerifyMailSuccessResponseDto> {
@@ -52,6 +60,7 @@ export class AuthController {
 
   @Post("/complete-signup")
   @HttpCode(HttpStatus.CREATED)
+  @ZodEncodeResponse(CompleteSignupResponseDtoSchema)
   async completeSignup(
     @Headers("authorization") authorization: string,
     @ZodBody(CompleteSignupRequestDtoSchema) body: CompleteSignupRequestDto,
@@ -68,6 +77,7 @@ export class AuthController {
 
   @Post("/login")
   @HttpCode(HttpStatus.OK)
+  @ZodEncodeResponse(LoginResponseDtoSchema)
   async login(
     @ZodBody(LoginRequestDtoSchema) body: LoginRequestDto,
   ): Promise<LoginSuccessResponseDto> {
@@ -82,7 +92,7 @@ export class AuthController {
           id: user.id,
           email: user.email,
           role: user.role,
-          createdAt: user.createdAt.toISOString(),
+          createdAt: user.createdAt,
           profile: { nickname: user.profile.nickname, age: user.profile.age },
         },
         accessToken: tokens.accessToken,
@@ -93,6 +103,7 @@ export class AuthController {
 
   @Post("/refresh-tokens")
   @HttpCode(HttpStatus.OK)
+  @ZodEncodeResponse(RefreshTokensResponseDtoSchema)
   async refreshTokens(
     @Headers("authorization") authorization: string,
   ): Promise<RefreshTokensSuccessResponseDto> {

--- a/apps/backend/src/common/filters/global-exception.filter.ts
+++ b/apps/backend/src/common/filters/global-exception.filter.ts
@@ -1,4 +1,3 @@
-import { ErrorResponseDto } from "@mindseed/api-types";
 import {
   ExceptionFilter,
   Catch,
@@ -18,13 +17,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       return res.status(statusCode).json({
         success: false,
         statusCode,
-      } satisfies ErrorResponseDto<any>);
+      });
     }
 
     console.error(exception);
     res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
       success: false,
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-    } satisfies ErrorResponseDto<any>);
+    });
   }
 }

--- a/apps/backend/src/common/interceptors/zod-encode-response.decorator.ts
+++ b/apps/backend/src/common/interceptors/zod-encode-response.decorator.ts
@@ -1,0 +1,6 @@
+import { UseInterceptors } from "@nestjs/common";
+import z from "zod";
+import { ZodEncodeResponseInterceptor } from "./zod-encode-response.interceptor";
+
+export const ZodEncodeResponse = <T extends z.ZodTypeAny>(schema: T) =>
+  UseInterceptors(new ZodEncodeResponseInterceptor(schema));

--- a/apps/backend/src/common/interceptors/zod-encode-response.interceptor.ts
+++ b/apps/backend/src/common/interceptors/zod-encode-response.interceptor.ts
@@ -1,0 +1,15 @@
+import { Injectable, ExecutionContext, NestInterceptor, CallHandler } from "@nestjs/common";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import * as z from "zod";
+
+@Injectable()
+export class ZodEncodeResponseInterceptor<T extends z.ZodTypeAny> implements NestInterceptor {
+  constructor(private readonly schema: T) {}
+
+  intercept(_ctx: ExecutionContext, next: CallHandler): Observable<z.input<T>> {
+    return next.handle().pipe(
+      map((data) => this.schema.encode(data))
+    );
+  }
+}

--- a/apps/backend/src/common/pipes/zod-body.decorator.ts
+++ b/apps/backend/src/common/pipes/zod-body.decorator.ts
@@ -1,5 +1,5 @@
 import { Body } from "@nestjs/common";
 import { ZodType } from "zod";
-import { ZodValidationPipe } from "./zod-validation.pipe";
+import { ZodDecoderPipe } from "./zod-decoder.pipe";
 
-export const ZodBody = (schema: ZodType) => Body(new ZodValidationPipe(schema));
+export const ZodBody = (schema: ZodType) => Body(new ZodDecoderPipe(schema));

--- a/apps/backend/src/common/pipes/zod-decoder.pipe.ts
+++ b/apps/backend/src/common/pipes/zod-decoder.pipe.ts
@@ -1,14 +1,14 @@
 import { PipeTransform, Injectable, BadRequestException } from "@nestjs/common";
-import { ZodType } from "zod";
+import z, { ZodType } from "zod";
 
 @Injectable()
-export class ZodValidationPipe implements PipeTransform {
+export class ZodDecoderPipe implements PipeTransform {
   constructor(private readonly schema: ZodType) {}
 
   transform(value: unknown) {
     const result = this.schema.safeParse(value);
     if (!result.success) {
-      throw new BadRequestException(result.error.flatten());
+      throw new BadRequestException(z.treeifyError(result.error));
     }
     return result.data;
   }

--- a/packages/api-types/src/auth/complete-signup.ts
+++ b/packages/api-types/src/auth/complete-signup.ts
@@ -4,13 +4,8 @@
  */
 
 import z from "zod";
-import {
-  ageSchema,
-  nicknameSchema,
-  passwordSchema,
-  type EmailAlreadyExistsErrorCode,
-} from "./common";
-import type { ErrorResponseDto, SuccessResponseDto } from "../shared";
+import { ageSchema, nicknameSchema, passwordSchema } from "./common";
+import { responseDtoSchema } from "../shared";
 
 export const CompleteSignupRequestDtoSchema = z.object({
   password: passwordSchema,
@@ -18,22 +13,16 @@ export const CompleteSignupRequestDtoSchema = z.object({
   age: ageSchema,
 });
 
-export type CompleteSignupRequestDto = z.infer<
-  typeof CompleteSignupRequestDtoSchema
->;
+export type CompleteSignupRequestDto = z.output<typeof CompleteSignupRequestDtoSchema>;
 
-export type CompleteSignupSuccessResponseDto = SuccessResponseDto<{
-  accessToken: string;
-  refreshToken: string;
-}>;
+export const CompleteSignupResponseDtoSchema = responseDtoSchema(
+  z.object({
+    accessToken: z.string(),
+    refreshToken: z.string(),
+  }),
+  z.enum(["EMAIL_ALREADY_EXISTS", "INVALID_SIGN_UP_TOKEN"])
+);
 
-export type CompleteSignupErrorCode =
-  | EmailAlreadyExistsErrorCode
-  | "INVALID_SIGN_UP_TOKEN";
-
-export type CompleteSignupErrorResponseDto =
-  ErrorResponseDto<CompleteSignupErrorCode>;
-
-export type CompleteSignupResponseDto =
-  | CompleteSignupSuccessResponseDto
-  | CompleteSignupErrorResponseDto;
+export type CompleteSignupResponseDto = z.output<typeof CompleteSignupResponseDtoSchema>;
+export type CompleteSignupSuccessResponseDto = Extract<CompleteSignupResponseDto, { success: true }>;
+export type CompleteSignupErrorResponseDto = Extract<CompleteSignupResponseDto, { success: false }>;

--- a/packages/api-types/src/auth/login.ts
+++ b/packages/api-types/src/auth/login.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import type { ErrorResponseDto, SuccessResponseDto } from "../shared";
+import { responseDtoSchema, dateTimeCodec } from "../shared";
 
 /*
  POST /auth/login
@@ -10,29 +10,34 @@ export const LoginRequestDtoSchema = z.object({
   password: z.string(),
 });
 
-export type LoginRequestDto = z.infer<typeof LoginRequestDtoSchema>;
+export type LoginRequestDto = z.output<typeof LoginRequestDtoSchema>;
 
-export type UserProfileDto = {
-  nickname: string;
-  age: number;
-};
+export const UserProfileDtoSchema = z.object({
+  nickname: z.string(),
+  age: z.int(),
+});
 
-export type UserDto = {
-  id: number;
-  email: string;
-  role: "USER" | "ADMIN";
-  createdAt: string;
-  profile: UserProfileDto;
-};
+export type UserProfileDto = z.output<typeof UserProfileDtoSchema>;
 
-export type LoginSuccessResponseDto = SuccessResponseDto<{
-  user: UserDto;
-  accessToken: string;
-  refreshToken: string;
-}>;
+export const UserDtoSchema = z.object({
+  id: z.int(),
+  email: z.email(),
+  role: z.enum(["USER", "ADMIN"]),
+  createdAt: dateTimeCodec,
+  profile: UserProfileDtoSchema,
+});
 
-export type LoginErrorCode = "INVALID_CREDENTIALS";
+export type UserDto = z.output<typeof UserDtoSchema>;
 
-export type LoginErrorResponseDto = ErrorResponseDto<LoginErrorCode>;
+export const LoginResponseDtoSchema = responseDtoSchema(
+  z.object({
+    user: UserDtoSchema,
+    accessToken: z.string(),
+    refreshToken: z.string(),
+  }),
+  z.enum(["INVALID_CREDENTIALS"])
+);
 
-export type LoginResponseDto = LoginSuccessResponseDto | LoginErrorResponseDto;
+export type LoginResponseDto = z.output<typeof LoginResponseDtoSchema>;
+export type LoginSuccessResponseDto = Extract<LoginResponseDto, { success: true }>;
+export type LoginErrorResponseDto = Extract<LoginResponseDto, { success: false }>;

--- a/packages/api-types/src/auth/refresh-tokens.ts
+++ b/packages/api-types/src/auth/refresh-tokens.ts
@@ -1,20 +1,19 @@
-import type { ErrorResponseDto, SuccessResponseDto } from "../shared";
-
 /*
  POST /auth/refresh-tokens
  Authorization: Bearer <refresh token>
  */
 
-export type RefreshTokensSuccessResponseDto = SuccessResponseDto<{
-  accessToken: string;
-  refreshToken: string;
-}>;
+import z from "zod";
+import { responseDtoSchema } from "../shared";
 
-export type RefreshTokensErrorCode = "INVALID_REFRESH_TOKEN";
+export const RefreshTokensResponseDtoSchema = responseDtoSchema(
+  z.object({
+    accessToken: z.string(),
+    refreshToken: z.string(),
+  }),
+  z.enum(["INVALID_REFRESH_TOKEN"])
+);
 
-export type RefreshTokensErrorResponseDto =
-  ErrorResponseDto<RefreshTokensErrorCode>;
-
-export type RefreshTokensResponseDto =
-  | RefreshTokensSuccessResponseDto
-  | RefreshTokensErrorResponseDto;
+export type RefreshTokensResponseDto = z.output<typeof RefreshTokensResponseDtoSchema>;
+export type RefreshTokensSuccessResponseDto = Extract<RefreshTokensResponseDto, { success: true }>;
+export type RefreshTokensErrorResponseDto = Extract<RefreshTokensResponseDto, { success: false }>;

--- a/packages/api-types/src/auth/send-mail.ts
+++ b/packages/api-types/src/auth/send-mail.ts
@@ -1,24 +1,21 @@
-import z from "zod";
-import type { ErrorResponseDto, SuccessResponseDto } from "../shared";
-import type { EmailAlreadyExistsErrorCode } from "./common";
-
 /*
  POST /auth/send-mail
  */
+
+import z from "zod";
+import { responseDtoSchema } from "../shared";
 
 export const SendMailRequestDtoSchema = z.object({
   email: z.email(),
 });
 
-export type SendMailRequestDto = z.infer<typeof SendMailRequestDtoSchema>;
+export type SendMailRequestDto = z.output<typeof SendMailRequestDtoSchema>;
 
-export type SendMailSuccessResponseDto = SuccessResponseDto<null>;
+export const SendMailResponseDtoSchema = responseDtoSchema(
+  z.null(),
+  z.enum(["EMAIL_ALREADY_EXISTS", "EMAIL_RATE_LIMITED", "VERIFICATION_COOLDOWN"])
+);
 
-export type SendMailErrorCode =
-  | EmailAlreadyExistsErrorCode
-  | "EMAIL_RATE_LIMITED"
-  | "VERIFICATION_COOLDOWN";
-
-export type SendMailErrorResponseDto = ErrorResponseDto<SendMailErrorCode>;
-
-export type SendMailResponseDto = SendMailSuccessResponseDto | SendMailErrorResponseDto;
+export type SendMailResponseDto = z.output<typeof SendMailResponseDtoSchema>;
+export type SendMailSuccessResponseDto = Extract<SendMailResponseDto, { success: true }>;
+export type SendMailErrorResponseDto = Extract<SendMailResponseDto, { success: false }>;

--- a/packages/api-types/src/auth/verify-mail.ts
+++ b/packages/api-types/src/auth/verify-mail.ts
@@ -4,22 +4,22 @@
 
 import z from "zod";
 import { verificationCodeSchema } from "./common";
-import type { ErrorResponseDto, SuccessResponseDto } from "../shared";
+import { responseDtoSchema } from "../shared";
 
 export const VerifyMailRequestDtoSchema = z.object({
   email: z.email(),
   code: verificationCodeSchema,
 });
 
-export type VerifyMailRequestDto = z.infer<typeof VerifyMailRequestDtoSchema>;
+export type VerifyMailRequestDto = z.output<typeof VerifyMailRequestDtoSchema>;
 
-export type VerifyMailSuccessResponseDto = SuccessResponseDto<{
-  signUpToken: string;
-}>;
+export const VerifyMailResponseDtoSchema = responseDtoSchema(
+  z.object({
+    signUpToken: z.string(),
+  }),
+  z.enum(["INVALID_VERIFICATION_CODE"])
+);
 
-export type VerifyMailErrorCode = "INVALID_VERIFICATION_CODE";
-
-export type VerifyMailErrorResponseDto = ErrorResponseDto<VerifyMailErrorCode>;
-
-export type VerifyMailResponseDto = VerifyMailSuccessResponseDto | VerifyMailErrorResponseDto;
-
+export type VerifyMailResponseDto = z.output<typeof VerifyMailResponseDtoSchema>;
+export type VerifyMailSuccessResponseDto = Extract<VerifyMailResponseDto, { success: true }>;
+export type VerifyMailErrorResponseDto = Extract<VerifyMailResponseDto, { success: false }>;

--- a/packages/api-types/src/shared.ts
+++ b/packages/api-types/src/shared.ts
@@ -1,10 +1,28 @@
-export type SuccessResponseDto<T> = {
-  success: true;
-  data: T;
-};
+import * as z from "zod";
 
-export type ErrorResponseDto<E> = {
-  success: false;
-  statusCode: number;
-  errorCode?: E;
-};
+export const successResponseDtoSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
+  z.object({
+    success: z.literal(true),
+    data: dataSchema,
+  });
+
+export const errorResponseDtoSchema = <E extends z.ZodTypeAny>(errorCodeSchema: E) =>
+  z.object({
+    success: z.literal(false),
+    statusCode: z.int(),
+    errorCode: errorCodeSchema.optional(),
+  });
+
+export const responseDtoSchema = <T extends z.ZodTypeAny, E extends z.ZodTypeAny>(
+  dataSchema: T,
+  errorCodeSchema: E
+) =>
+  z.discriminatedUnion("success", [
+    successResponseDtoSchema(dataSchema),
+    errorResponseDtoSchema(errorCodeSchema),
+  ]);
+
+export const dateTimeCodec = z.codec(z.iso.datetime(), z.date(), {
+  decode: (str) => new Date(str),
+  encode: (date) => date.toISOString(),
+});


### PR DESCRIPTION
## 요약

- #34 구현
- `api-types`: response 역시 Zod schema를 사용하도록 변경하였습니다.
- `backend`: response를 해당 schema 사용을 통해 encode 하는 동작을 추가하였습니다.

## 구현 상세

- `api-types`: Zod 기반으로 response schema가 작성되었습니다.
- `backend`
    - schema를 사용하여 response를 encode 하는 interceptor가 추가되었습니다.
    - controller에서 해당 interceptor를 사용합니다.