### PR TITLE
User - UserProfile의 nullable 관계 수정

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -97,7 +97,10 @@ export class AuthController {
           email: user.email,
           role: user.role,
           createdAt: user.createdAt,
-          profile: { nickname: user.profile.nickname, age: user.profile.age },
+          profile: {
+            nickname: user.userProfile.nickname,
+            age: user.userProfile.age,
+          },
         },
         accessToken: tokens.accessToken,
         refreshToken: tokens.refreshToken,

--- a/apps/backend/src/user/user.controller.ts
+++ b/apps/backend/src/user/user.controller.ts
@@ -24,7 +24,10 @@ export class UserController {
         email: user.email,
         role: user.role,
         createdAt: user.createdAt,
-        profile: { nickname: user.profile.nickname, age: user.profile.age },
+        profile: {
+          nickname: user.userProfile.nickname,
+          age: user.userProfile.age,
+        },
       },
     };
   }

--- a/apps/backend/src/user/user.controller.ts
+++ b/apps/backend/src/user/user.controller.ts
@@ -24,9 +24,9 @@ export class UserController {
         email: user.email,
         role: user.role,
         createdAt: user.createdAt,
-        profile: {
-          nickname: user.userProfile.nickname,
-          age: user.userProfile.age,
+        profile: user.profile && {
+          nickname: user.profile.nickname,
+          age: user.profile.age,
         },
       },
     };

--- a/apps/backend/src/user/user.entity.ts
+++ b/apps/backend/src/user/user.entity.ts
@@ -6,12 +6,21 @@ import {
   PrimaryGeneratedColumn,
 } from "typeorm";
 import { UserProfile } from "./user-profile.entity";
+import assert from "node:assert";
 
 export enum UserRole {
   USER = "USER",
   ADMIN = "ADMIN",
 }
 
+// 2026-03-19: domain constraint 수준의 invariant를 유지하기 위해 domain 객체
+// 레이어를 추가하는 것은 현재 프로젝트 스펙 상 오버헤드라고 판단하였습니다.
+// 따라서 현재는 getter 기반으로 invariant를 표현했습니다.
+
+/*
+ * invariant (1): .profile이 non-null이라면, .role === USER이며,
+ * 그 반대도 마찬가지이다.
+ */
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
@@ -30,5 +39,17 @@ export class User {
   createdAt: Date;
 
   @OneToOne(() => UserProfile, (profile) => profile.user, { cascade: true })
-  profile: UserProfile;
+  profile: UserProfile | null;
+
+  /*
+   * (1) 을 type level에서 구현한다.
+   * assumption: userProfile이 접근되는 User는 USER role을 가진다.
+   */
+  get userProfile(): UserProfile {
+    assert(
+      this.role === UserRole.USER,
+      "User: .userProfile can be used iff .role === UserRole.USER",
+    );
+    return this.profile!;
+  }
 }

--- a/apps/backend/src/user/user.service.ts
+++ b/apps/backend/src/user/user.service.ts
@@ -28,6 +28,10 @@ export class UserService {
     });
   }
 
+  /*
+   * USER role로 사용자를 생성한다.
+   * @returns 생성된 사용자
+   */
   async create(
     email: string,
     hashedPassword: string,

--- a/packages/api-types/src/auth/login.ts
+++ b/packages/api-types/src/auth/login.ts
@@ -19,12 +19,13 @@ export const UserProfileDtoSchema = z.object({
 
 export type UserProfileDto = z.output<typeof UserProfileDtoSchema>;
 
+// invariant: profile은 role === "ADMIN" 일 때만 null이다.
 export const UserDtoSchema = z.object({
   id: z.int(),
   email: z.email(),
   role: z.enum(["USER", "ADMIN"]),
   createdAt: dateTimeCodec,
-  profile: UserProfileDtoSchema,
+  profile: UserProfileDtoSchema.nullable(),
 });
 
 export type UserDto = z.output<typeof UserDtoSchema>;


### PR DESCRIPTION
## 요약

- User의 profile 프로퍼티는 설계상 null이 될 수 있으므로 이를 수정하였습니다.
- 이와 관련하여 role과 profile 프로퍼티 간의 invariant가 존재하는데, 현재는 이를 암묵적으로 두었습니다.

## 내용

기존의 User entity는 profile이 nullable이 아니었는데, 이는 DB의 데이터 상태를 제대로 표현하지 못하므로 nullable이 되도록 수정하였습니다.

이로 인해 User의 프로퍼티 간에는 다음 invariant가 존재하게 되었습니다.

> `profile`은 `role`이 `USER`일 때만 non-null 이다.

이를 다음과 같이 구현하였습니다.

- `api-types`: DTO 상에서는 TS의 타입 기반으로 표현이 가능하나 우선은 그렇게까지 하지는 않았고, 주석만 달아두었습니다.
- `backend`: TypeORM 라이브러리에선 class 기반으로 entity를 작성하기에 타입 기반 표현이 불가능합니다. 때문에 위와 같이 주석만 달아두었습니다. 또한 코드에서 non-null assertion (`!`) 을 피하기 위해 getter 기반 helper를 추가하였으나 좋은 해결책은 아니라고 생각합니다. 현재는 잘 작동하나 추후 필요한 경우 수정할 수 있도록 하겠습니다.