### PR TITLE
/attachments, /posts API schema

### DIFF
--- a/packages/api-types/src/attachments/begin.ts
+++ b/packages/api-types/src/attachments/begin.ts
@@ -1,0 +1,19 @@
+/*
+ POST /attachments/begin
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+
+export const BeginAttachmentUploadResponseDtoSchema = responseDtoSchema(
+  z.object({
+    attachmentId: z.int(),
+    presignedUrl: z.url(),
+  }),
+  z.enum([])
+);
+
+export type BeginAttachmentUploadResponseDto = z.output<typeof BeginAttachmentUploadResponseDtoSchema>;
+export type BeginAttachmentUploadSuccessResponseDto = Extract<BeginAttachmentUploadResponseDto, { success: true }>;
+export type BeginAttachmentUploadErrorResponseDto = Extract<BeginAttachmentUploadResponseDto, { success: false }>;

--- a/packages/api-types/src/attachments/confirm.ts
+++ b/packages/api-types/src/attachments/confirm.ts
@@ -1,0 +1,22 @@
+/*
+ POST /attachments/confirm
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+
+export const ConfirmAttachmentUploadRequestDtoSchema = z.object({
+  attachmentId: z.int(),
+});
+
+export type ConfirmAttachmentUploadRequestDto = z.output<typeof ConfirmAttachmentUploadRequestDtoSchema>;
+
+export const ConfirmAttachmentUploadResponseDtoSchema = responseDtoSchema(
+  z.null(),
+  z.enum(["ATTACHMENT_NOT_FOUND", "ATTACHMENT_ALREADY_CONFIRMED", "ATTACHMENT_NOT_UPLOADED"])
+);
+
+export type ConfirmAttachmentUploadResponseDto = z.output<typeof ConfirmAttachmentUploadResponseDtoSchema>;
+export type ConfirmAttachmentUploadSuccessResponseDto = Extract<ConfirmAttachmentUploadResponseDto, { success: true }>;
+export type ConfirmAttachmentUploadErrorResponseDto = Extract<ConfirmAttachmentUploadResponseDto, { success: false }>;

--- a/packages/api-types/src/auth/common.ts
+++ b/packages/api-types/src/auth/common.ts
@@ -23,4 +23,4 @@ export const ageSchema = z.int().min(0);
 
 // shared error codes
 
-export type EmailAlreadyExistsErrorCode = "EMAIL_ALREADY_EXISTS";
+export const EmailAlreadyExistsErrorCode = "EMAIL_ALREADY_EXISTS";

--- a/packages/api-types/src/auth/complete-signup.ts
+++ b/packages/api-types/src/auth/complete-signup.ts
@@ -5,7 +5,7 @@
 
 import z from "zod";
 import { ageSchema, nicknameSchema, passwordSchema } from "./common";
-import { responseDtoSchema } from "../shared";
+import { responseDtoSchema } from "../helpers";
 
 export const CompleteSignupRequestDtoSchema = z.object({
   password: passwordSchema,

--- a/packages/api-types/src/auth/complete-signup.ts
+++ b/packages/api-types/src/auth/complete-signup.ts
@@ -4,7 +4,7 @@
  */
 
 import z from "zod";
-import { ageSchema, nicknameSchema, passwordSchema } from "./common";
+import { ageSchema, EmailAlreadyExistsErrorCode, nicknameSchema, passwordSchema } from "./common";
 import { responseDtoSchema } from "../helpers";
 
 export const CompleteSignupRequestDtoSchema = z.object({
@@ -20,7 +20,7 @@ export const CompleteSignupResponseDtoSchema = responseDtoSchema(
     accessToken: z.string(),
     refreshToken: z.string(),
   }),
-  z.enum(["EMAIL_ALREADY_EXISTS", "INVALID_SIGN_UP_TOKEN"])
+  z.enum([EmailAlreadyExistsErrorCode, "INVALID_SIGN_UP_TOKEN"])
 );
 
 export type CompleteSignupResponseDto = z.output<typeof CompleteSignupResponseDtoSchema>;

--- a/packages/api-types/src/auth/login.ts
+++ b/packages/api-types/src/auth/login.ts
@@ -1,9 +1,10 @@
-import z from "zod";
-import { responseDtoSchema, dateTimeCodec } from "../shared";
-
 /*
  POST /auth/login
  */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import { UserDtoSchema } from "../common/user-dto";
 
 export const LoginRequestDtoSchema = z.object({
   email: z.email(),
@@ -11,24 +12,6 @@ export const LoginRequestDtoSchema = z.object({
 });
 
 export type LoginRequestDto = z.output<typeof LoginRequestDtoSchema>;
-
-export const UserProfileDtoSchema = z.object({
-  nickname: z.string(),
-  age: z.int(),
-});
-
-export type UserProfileDto = z.output<typeof UserProfileDtoSchema>;
-
-// invariant: profile은 role === "ADMIN" 일 때만 null이다.
-export const UserDtoSchema = z.object({
-  id: z.int(),
-  email: z.email(),
-  role: z.enum(["USER", "ADMIN"]),
-  createdAt: dateTimeCodec,
-  profile: UserProfileDtoSchema.nullable(),
-});
-
-export type UserDto = z.output<typeof UserDtoSchema>;
 
 export const LoginResponseDtoSchema = responseDtoSchema(
   z.object({

--- a/packages/api-types/src/auth/refresh-tokens.ts
+++ b/packages/api-types/src/auth/refresh-tokens.ts
@@ -4,7 +4,7 @@
  */
 
 import z from "zod";
-import { responseDtoSchema } from "../shared";
+import { responseDtoSchema } from "../helpers";
 
 export const RefreshTokensResponseDtoSchema = responseDtoSchema(
   z.object({

--- a/packages/api-types/src/auth/send-mail.ts
+++ b/packages/api-types/src/auth/send-mail.ts
@@ -4,6 +4,7 @@
 
 import z from "zod";
 import { responseDtoSchema } from "../helpers";
+import { EmailAlreadyExistsErrorCode } from "./common";
 
 export const SendMailRequestDtoSchema = z.object({
   email: z.email(),
@@ -13,7 +14,7 @@ export type SendMailRequestDto = z.output<typeof SendMailRequestDtoSchema>;
 
 export const SendMailResponseDtoSchema = responseDtoSchema(
   z.null(),
-  z.enum(["EMAIL_ALREADY_EXISTS", "EMAIL_RATE_LIMITED", "VERIFICATION_COOLDOWN"])
+  z.enum([EmailAlreadyExistsErrorCode, "EMAIL_RATE_LIMITED", "VERIFICATION_COOLDOWN"])
 );
 
 export type SendMailResponseDto = z.output<typeof SendMailResponseDtoSchema>;

--- a/packages/api-types/src/auth/send-mail.ts
+++ b/packages/api-types/src/auth/send-mail.ts
@@ -3,7 +3,7 @@
  */
 
 import z from "zod";
-import { responseDtoSchema } from "../shared";
+import { responseDtoSchema } from "../helpers";
 
 export const SendMailRequestDtoSchema = z.object({
   email: z.email(),

--- a/packages/api-types/src/auth/verify-mail.ts
+++ b/packages/api-types/src/auth/verify-mail.ts
@@ -4,7 +4,7 @@
 
 import z from "zod";
 import { verificationCodeSchema } from "./common";
-import { responseDtoSchema } from "../shared";
+import { responseDtoSchema } from "../helpers";
 
 export const VerifyMailRequestDtoSchema = z.object({
   email: z.email(),

--- a/packages/api-types/src/common/date-time-codec.ts
+++ b/packages/api-types/src/common/date-time-codec.ts
@@ -1,0 +1,6 @@
+import z from "zod";
+
+export const dateTimeCodec = z.codec(z.iso.datetime(), z.date(), {
+  decode: (str) => new Date(str),
+  encode: (date) => date.toISOString(),
+});

--- a/packages/api-types/src/common/user-dto.ts
+++ b/packages/api-types/src/common/user-dto.ts
@@ -1,0 +1,13 @@
+import z from "zod";
+import { dateTimeCodec } from "./date-time-codec";
+import { UserProfileDtoSchema } from "./user-profile-dto";
+
+export const UserDtoSchema = z.object({
+  id: z.int(),
+  email: z.email(),
+  role: z.enum(["USER", "ADMIN"]),
+  createdAt: dateTimeCodec,
+  profile: UserProfileDtoSchema,
+});
+
+export type UserDto = z.output<typeof UserDtoSchema>;

--- a/packages/api-types/src/common/user-profile-dto.ts
+++ b/packages/api-types/src/common/user-profile-dto.ts
@@ -1,0 +1,8 @@
+import z from "zod";
+
+export const UserProfileDtoSchema = z.object({
+  nickname: z.string(),
+  age: z.int(),
+});
+
+export type UserProfileDto = z.output<typeof UserProfileDtoSchema>;

--- a/packages/api-types/src/helpers.ts
+++ b/packages/api-types/src/helpers.ts
@@ -22,7 +22,3 @@ export const responseDtoSchema = <T extends z.ZodTypeAny, E extends z.ZodTypeAny
     errorResponseDtoSchema(errorCodeSchema),
   ]);
 
-export const dateTimeCodec = z.codec(z.iso.datetime(), z.date(), {
-  decode: (str) => new Date(str),
-  encode: (date) => date.toISOString(),
-});

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -11,3 +11,11 @@ export * from "./users/current";
 
 export * from "./attachments/begin";
 export * from "./attachments/confirm";
+
+export * from "./posts/common";
+export * from "./posts/create-post";
+export * from "./posts/list-posts";
+export * from "./posts/get-post";
+export * from "./posts/update-post";
+export * from "./posts/set-post-like";
+export * from "./posts/delete-post";

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -8,3 +8,6 @@ export * from "./auth/send-mail";
 export * from "./auth/verify-mail";
 
 export * from "./users/current";
+
+export * from "./attachments/begin";
+export * from "./attachments/confirm";

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./shared";
+export * from "./helpers";
 
 export * from "./auth/common";
 export * from "./auth/complete-signup";

--- a/packages/api-types/src/posts/common.ts
+++ b/packages/api-types/src/posts/common.ts
@@ -1,0 +1,41 @@
+import z from "zod";
+import { dateTimeCodec } from "../common/date-time-codec";
+
+export const PostContentSchema = z.string().min(1).max(200);
+
+export const PostCategorySchema = z.enum(["dummy1", "dummy2", "dummy3"]);
+
+export const PostAttachmentsSchema = z.array(z.int()).max(3);
+
+export const AttachmentDtoSchema = z.object({
+  id: z.int(),
+  url: z.url(),
+});
+
+export type AttachmentDto = z.output<typeof AttachmentDtoSchema>;
+
+export const PostAuthorNicknameSchema = z.string().min(2).max(10);
+
+export const PostAuthorDtoSchema = z.object({
+  nickname: PostAuthorNicknameSchema,
+});
+
+export const PostDtoSchema = z.object({
+  id: z.int(),
+  content: PostContentSchema,
+  category: PostCategorySchema,
+  author: PostAuthorDtoSchema,
+  attachments: z.array(AttachmentDtoSchema),
+  likeCount: z.int(),
+  isOwner: z.boolean(),
+  isLiked: z.boolean(),
+  createdAt: dateTimeCodec,
+  updatedAt: dateTimeCodec,
+});
+
+export type PostDto = z.output<typeof PostDtoSchema>;
+
+// shared error codes
+
+export const PostNotFoundErrorCode = "POST_NOT_FOUND";
+export const NotPostAuthorErrorCode = "NOT_POST_AUTHOR";

--- a/packages/api-types/src/posts/create-post.ts
+++ b/packages/api-types/src/posts/create-post.ts
@@ -1,0 +1,28 @@
+/*
+ POST /posts
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import { PostAttachmentsSchema, PostAuthorNicknameSchema, PostCategorySchema, PostContentSchema } from "./common";
+
+export const CreatePostRequestDtoSchema = z.object({
+  content: PostContentSchema,
+  category: PostCategorySchema,
+  nickname: PostAuthorNicknameSchema,
+  attachmentIds: PostAttachmentsSchema,
+});
+
+export type CreatePostRequestDto = z.output<typeof CreatePostRequestDtoSchema>;
+
+export const CreatePostResponseDtoSchema = responseDtoSchema(
+  z.object({
+    id: z.int(),
+  }),
+  z.enum(["ATTACHMENT_NOT_FOUND", "ATTACHMENT_ALREADY_ASSOCIATED"])
+);
+
+export type CreatePostResponseDto = z.output<typeof CreatePostResponseDtoSchema>;
+export type CreatePostSuccessResponseDto = Extract<CreatePostResponseDto, { success: true }>;
+export type CreatePostErrorResponseDto = Extract<CreatePostResponseDto, { success: false }>;

--- a/packages/api-types/src/posts/delete-post.ts
+++ b/packages/api-types/src/posts/delete-post.ts
@@ -1,0 +1,17 @@
+/*
+ DELETE /posts/:id
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import { PostNotFoundErrorCode, NotPostAuthorErrorCode } from "./common";
+
+export const DeletePostResponseDtoSchema = responseDtoSchema(
+  z.null(),
+  z.enum([PostNotFoundErrorCode, NotPostAuthorErrorCode])
+);
+
+export type DeletePostResponseDto = z.output<typeof DeletePostResponseDtoSchema>;
+export type DeletePostSuccessResponseDto = Extract<DeletePostResponseDto, { success: true }>;
+export type DeletePostErrorResponseDto = Extract<DeletePostResponseDto, { success: false }>;

--- a/packages/api-types/src/posts/get-post.ts
+++ b/packages/api-types/src/posts/get-post.ts
@@ -1,0 +1,17 @@
+/*
+ GET /posts/:id
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import { PostDtoSchema, PostNotFoundErrorCode } from "./common";
+
+export const GetPostResponseDtoSchema = responseDtoSchema(
+  PostDtoSchema,
+  z.enum([PostNotFoundErrorCode])
+);
+
+export type GetPostResponseDto = z.output<typeof GetPostResponseDtoSchema>;
+export type GetPostSuccessResponseDto = Extract<GetPostResponseDto, { success: true }>;
+export type GetPostErrorResponseDto = Extract<GetPostResponseDto, { success: false }>;

--- a/packages/api-types/src/posts/list-posts.ts
+++ b/packages/api-types/src/posts/list-posts.ts
@@ -1,0 +1,29 @@
+/*
+ GET /posts
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import { PostCategorySchema, PostDtoSchema } from "./common";
+
+export const ListPostsQueryDtoSchema = z.object({
+  cursor: z.int().optional(),
+  limit: z.int().default(10),
+  category: PostCategorySchema.optional(),
+  orderBy: z.enum(["createdAt"]).default("createdAt"),
+});
+
+export type ListPostsQueryDto = z.output<typeof ListPostsQueryDtoSchema>;
+
+export const ListPostsResponseDtoSchema = responseDtoSchema(
+  z.object({
+    posts: z.array(PostDtoSchema),
+    nextCursor: z.int().nullable(),
+  }),
+  z.enum([])
+);
+
+export type ListPostsResponseDto = z.output<typeof ListPostsResponseDtoSchema>;
+export type ListPostsSuccessResponseDto = Extract<ListPostsResponseDto, { success: true }>;
+export type ListPostsErrorResponseDto = Extract<ListPostsResponseDto, { success: false }>;

--- a/packages/api-types/src/posts/set-post-like.ts
+++ b/packages/api-types/src/posts/set-post-like.ts
@@ -1,0 +1,23 @@
+/*
+ PUT /posts/:id/like
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import { PostNotFoundErrorCode } from "./common";
+
+export const SetPostLikeRequestDtoSchema = z.object({
+  liked: z.boolean(),
+});
+
+export type SetPostLikeRequestDto = z.output<typeof SetPostLikeRequestDtoSchema>;
+
+export const SetPostLikeResponseDtoSchema = responseDtoSchema(
+  z.null(),
+  z.enum([PostNotFoundErrorCode])
+);
+
+export type SetPostLikeResponseDto = z.output<typeof SetPostLikeResponseDtoSchema>;
+export type SetPostLikeSuccessResponseDto = Extract<SetPostLikeResponseDto, { success: true }>;
+export type SetPostLikeErrorResponseDto = Extract<SetPostLikeResponseDto, { success: false }>;

--- a/packages/api-types/src/posts/update-post.ts
+++ b/packages/api-types/src/posts/update-post.ts
@@ -1,0 +1,25 @@
+/*
+ PUT /posts/:id
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import { PostCategorySchema, PostNotFoundErrorCode, NotPostAuthorErrorCode, PostContentSchema, PostAttachmentsSchema } from "./common";
+
+export const UpdatePostRequestDtoSchema = z.object({
+  content: PostContentSchema,
+  category: PostCategorySchema,
+  attachmentIds: PostAttachmentsSchema,
+});
+
+export type UpdatePostRequestDto = z.output<typeof UpdatePostRequestDtoSchema>;
+
+export const UpdatePostResponseDtoSchema = responseDtoSchema(
+  z.null(),
+  z.enum([PostNotFoundErrorCode, NotPostAuthorErrorCode, "ATTACHMENT_NOT_FOUND", "ATTACHMENT_ALREADY_ASSOCIATED"])
+);
+
+export type UpdatePostResponseDto = z.output<typeof UpdatePostResponseDtoSchema>;
+export type UpdatePostSuccessResponseDto = Extract<UpdatePostResponseDto, { success: true }>;
+export type UpdatePostErrorResponseDto = Extract<UpdatePostResponseDto, { success: false }>;

--- a/packages/api-types/src/users/current.ts
+++ b/packages/api-types/src/users/current.ts
@@ -1,10 +1,10 @@
-import z from "zod";
-import { responseDtoSchema } from "../shared";
-import { UserDtoSchema } from "../auth/login";
-
 /*
  GET /users/current
  */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import { UserDtoSchema } from "../common/user-dto";
 
 export const GetCurrentUserResponseDtoSchema = responseDtoSchema(
   UserDtoSchema,

--- a/packages/api-types/src/users/current.ts
+++ b/packages/api-types/src/users/current.ts
@@ -1,5 +1,6 @@
 /*
  GET /users/current
+ Auth: any authenticated user
  */
 
 import z from "zod";


### PR DESCRIPTION
## 요약

- #43 API 작성 완료
- 커뮤니티의 글 기능을 위한 파일 업로드 및 글 관련 API schema를 작성하였습니다.

## 내용

- `api-types`: 작업 전 공통 타입 분리의 리팩토링을 작성하였고, 이후 엔드포인트들을 추가하였습니다.

## 비고

- 댓글과 관련된 부분은 아직 schema 상에서는 작성되지 않았습니다.