### PR TITLE
Backend: PostController 구현

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { AttachmentModule } from "./attachment/attachment.module";
 import { PostModule } from "./post/post.module";
 import { Post } from "./post/post.entity";
 import { Attachment } from "./attachment/attachment.entity";
+import { PostLike } from "./post/post-like.entity";
 
 @Module({
   imports: [
@@ -39,7 +40,7 @@ import { Attachment } from "./attachment/attachment.entity";
         username: db.username,
         password: db.password,
         database: db.database,
-        entities: [User, UserProfile, RefreshToken, Post, Attachment],
+        entities: [User, UserProfile, RefreshToken, Post, PostLike, Attachment],
         synchronize: process.env.NODE_ENV !== "production",
       }),
     }),

--- a/apps/backend/src/attachment/attachment.controller.ts
+++ b/apps/backend/src/attachment/attachment.controller.ts
@@ -10,7 +10,7 @@ import type {
   ConfirmAttachmentUploadSuccessResponseDto,
 } from "@mindseed/api-types";
 import { AttachmentService } from "./attachment.service";
-import { ZodBody } from "src/common/pipes/zod-body.decorator";
+import { ZodBody } from "src/common/pipes/zod-validation.decorator";
 import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
 import { UserOnly } from "src/auth/decorators/auth.decorators";
 

--- a/apps/backend/src/attachment/attachment.service.spec.ts
+++ b/apps/backend/src/attachment/attachment.service.spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
 import { DataSource, Repository } from "typeorm";
 import PGMem from "pg-mem";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { AttachmentService } from "./attachment.service";
 import {
   AttachmentAlreadyConfirmedError,
@@ -13,27 +12,17 @@ import { Attachment } from "./attachment.entity";
 import { Post } from "../post/post.entity";
 import { User } from "../user/user.entity";
 import { UserProfile } from "../user/user-profile.entity";
-import { S3_CLIENT } from "src/s3-storage/s3-storage.module";
-import { s3Config } from "src/config";
 import { initializePgMem } from "src/test/pg-mem.helper";
-import { NotFound } from "@aws-sdk/client-s3";
-
-jest.mock("@aws-sdk/s3-request-presigner");
+import { S3StorageService } from "src/s3-storage/s3-storage.service";
+import { FakeS3StorageService } from "src/s3-storage/s3-storage.service.fake";
 
 const entities = [UserProfile, User, Post, Attachment];
-
-const mockS3Config = {
-  region: "us-east-1",
-  accessKeyId: "test-key",
-  secretAccessKey: "test-secret",
-  bucket: "test-bucket",
-};
 
 describe("AttachmentService", () => {
   let module: TestingModule;
   let attachmentService: AttachmentService;
   let attachmentRepository: Repository<Attachment>;
-  let mockS3Client: { send: jest.Mock };
+  let fakeS3: FakeS3StorageService;
   let dataSource: DataSource;
   let dbBackup: PGMem.IBackup;
 
@@ -42,7 +31,7 @@ describe("AttachmentService", () => {
     dataSource = ds;
     dbBackup = backup;
 
-    mockS3Client = { send: jest.fn() };
+    fakeS3 = new FakeS3StorageService();
 
     module = await Test.createTestingModule({
       providers: [
@@ -51,8 +40,7 @@ describe("AttachmentService", () => {
           provide: getRepositoryToken(Attachment),
           useValue: dataSource.getRepository(Attachment),
         },
-        { provide: S3_CLIENT, useValue: mockS3Client },
-        { provide: s3Config.KEY, useValue: mockS3Config },
+        { provide: S3StorageService, useValue: fakeS3 },
       ],
     }).compile();
 
@@ -62,8 +50,7 @@ describe("AttachmentService", () => {
 
   beforeEach(() => {
     dbBackup.restore();
-    mockS3Client.send.mockReset();
-    jest.mocked(getSignedUrl).mockReset();
+    fakeS3.reset();
     jest.restoreAllMocks();
   });
 
@@ -74,10 +61,6 @@ describe("AttachmentService", () => {
 
   describe("beginAttachmentUpload", () => {
     it("success: attachment 저장, presigned URL 반환", async () => {
-      // Given
-      const fakePresignedUrl = "https://s3.example.com/presigned";
-      jest.mocked(getSignedUrl).mockResolvedValue(fakePresignedUrl);
-
       // When
       const result = await attachmentService.beginAttachmentUpload();
 
@@ -87,7 +70,9 @@ describe("AttachmentService", () => {
       });
       expect(saved).not.toBeNull();
       expect(saved!.confirmed).toBe(false);
-      expect(result.presignedUrl).toBe(fakePresignedUrl);
+      expect(
+        fakeS3.isPresignedUrlValid(saved!.s3Key, result.presignedUrl),
+      ).toBe(true);
     });
 
     it("attachment 저장 실패 처리", async () => {
@@ -105,12 +90,11 @@ describe("AttachmentService", () => {
 
       // Then: throws, presigned URL 생성하지 않음
       await expect(result).rejects.toThrow();
-      expect(jest.mocked(getSignedUrl)).not.toHaveBeenCalled();
     });
 
     it("presigned URL 생성 실패 처리", async () => {
       // Given: presigned URL 생성이 실패하는 경우
-      jest.mocked(getSignedUrl).mockRejectedValueOnce(new Error("S3 failure"));
+      fakeS3.shouldFailOnPresigning = true;
 
       // When
       const result = attachmentService.beginAttachmentUpload();
@@ -130,7 +114,7 @@ describe("AttachmentService", () => {
           s3Key: "attachments/1",
         }),
       );
-      mockS3Client.send.mockResolvedValue({});
+      fakeS3.put(attachment.s3Key);
 
       // When
       await attachmentService.confirmAttachmentUpload(attachment.id);
@@ -179,8 +163,6 @@ describe("AttachmentService", () => {
           s3Key: "attachments/1",
         }),
       );
-
-      mockS3Client.send.mockRejectedValue(Object.create(NotFound.prototype));
 
       // When
       const result = attachmentService.confirmAttachmentUpload(attachment.id);

--- a/apps/backend/src/attachment/attachment.service.ts
+++ b/apps/backend/src/attachment/attachment.service.ts
@@ -1,25 +1,15 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
-import type { ConfigType } from "@nestjs/config";
-import { Inject } from "@nestjs/common";
-import {
-  HeadObjectCommand,
-  NotFound,
-  PutObjectCommand,
-  S3Client,
-} from "@aws-sdk/client-s3";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { randomUUID } from "crypto";
 import { Attachment } from "./attachment.entity";
-import { S3_CLIENT } from "src/s3-storage/s3-storage.module";
-import { s3Config } from "src/config";
+import { createAttachmentS3Key } from "./attachment-s3-key.helper";
+import { S3StorageService } from "src/s3-storage/s3-storage.service";
 import {
   AttachmentAlreadyConfirmedError,
   AttachmentNotFoundError,
   AttachmentNotUploadedError,
 } from "./attachment.errors";
-import { createAttachmentS3Key } from "./attachment-s3-key.helper";
 
 export type BeginAttachmentUploadResult = {
   attachmentId: number;
@@ -35,9 +25,7 @@ export class AttachmentService {
   constructor(
     @InjectRepository(Attachment)
     private readonly attachmentRepository: Repository<Attachment>,
-    @Inject(S3_CLIENT) private readonly s3Client: S3Client,
-    @Inject(s3Config.KEY)
-    private readonly s3cfg: ConfigType<typeof s3Config>,
+    private readonly s3StorageService: S3StorageService,
   ) {}
 
   async beginAttachmentUpload(): Promise<BeginAttachmentUploadResult> {
@@ -47,11 +35,7 @@ export class AttachmentService {
     );
 
     try {
-      const presignedUrl = await getSignedUrl(
-        this.s3Client,
-        new PutObjectCommand({ Bucket: this.s3cfg.bucket!, Key: s3Key }),
-        { expiresIn: 600 },
-      );
+      const presignedUrl = await this.s3StorageService.getUploadUrl(s3Key, 600);
       return { attachmentId: attachment.id, presignedUrl };
     } catch (error) {
       await this.attachmentRepository.delete(attachment.id);
@@ -71,18 +55,8 @@ export class AttachmentService {
       throw new AttachmentAlreadyConfirmedError();
     }
 
-    try {
-      await this.s3Client.send(
-        new HeadObjectCommand({
-          Bucket: this.s3cfg.bucket!,
-          Key: attachment.s3Key,
-        }),
-      );
-    } catch (error) {
-      if (error instanceof NotFound) {
-        throw new AttachmentNotUploadedError();
-      }
-      throw error;
+    if (!(await this.s3StorageService.exists(attachment.s3Key))) {
+      throw new AttachmentNotUploadedError();
     }
 
     attachment.confirmed = true;

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -28,7 +28,7 @@ import type {
   RefreshTokensSuccessResponseDto,
 } from "@mindseed/api-types";
 import { AuthService } from "./auth.service";
-import { ZodBody } from "src/common/pipes/zod-body.decorator";
+import { ZodBody } from "src/common/pipes/zod-validation.decorator";
 import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
 import { UnAuthenticated } from "./decorators/auth.decorators";
 

--- a/apps/backend/src/common/pipes/zod-body.decorator.ts
+++ b/apps/backend/src/common/pipes/zod-body.decorator.ts
@@ -1,5 +1,0 @@
-import { Body } from "@nestjs/common";
-import { ZodType } from "zod";
-import { ZodDecoderPipe } from "./zod-decoder.pipe";
-
-export const ZodBody = (schema: ZodType) => Body(new ZodDecoderPipe(schema));

--- a/apps/backend/src/common/pipes/zod-validation.decorator.ts
+++ b/apps/backend/src/common/pipes/zod-validation.decorator.ts
@@ -1,0 +1,8 @@
+import { Body, Param, Query } from "@nestjs/common";
+import { ZodType } from "zod";
+import { ZodDecoderPipe } from "./zod-decoder.pipe";
+
+export const ZodBody = (schema: ZodType) => Body(new ZodDecoderPipe(schema));
+export const ZodQuery = (schema: ZodType) => Query(new ZodDecoderPipe(schema));
+export const ZodParam = (param: string, schema: ZodType) =>
+  Param(param, new ZodDecoderPipe(schema));

--- a/apps/backend/src/post/post-mutation.service.spec.ts
+++ b/apps/backend/src/post/post-mutation.service.spec.ts
@@ -3,13 +3,12 @@ import { getDataSourceToken, getRepositoryToken } from "@nestjs/typeorm";
 import { DataSource, Repository } from "typeorm";
 import PGMem from "pg-mem";
 import { randomUUID } from "crypto";
-import { PostService } from "./post.service";
+import { PostMutationService } from "./post-mutation.service";
 import {
   AttachmentAlreadyAssociatedError,
   AttachmentNotFoundError,
   NotPostAuthorError,
   PostNotFoundError,
-  InvalidCursorError,
 } from "./post.errors";
 import { Post, PostCategory } from "./post.entity";
 import { PostLike } from "./post-like.entity";
@@ -69,9 +68,9 @@ async function saveTestAttachment(
   );
 }
 
-describe("PostService", () => {
+describe("PostMutationService", () => {
   let module: TestingModule;
-  let postService: PostService;
+  let postMutationService: PostMutationService;
   let postRepository: Repository<Post>;
   let postLikeRepository: Repository<PostLike>;
   let attachmentRepository: Repository<Attachment>;
@@ -89,7 +88,7 @@ describe("PostService", () => {
 
     module = await Test.createTestingModule({
       providers: [
-        PostService,
+        PostMutationService,
         {
           provide: getRepositoryToken(Post),
           useValue: dataSource.getRepository(Post),
@@ -110,7 +109,7 @@ describe("PostService", () => {
       ],
     }).compile();
 
-    postService = module.get(PostService);
+    postMutationService = module.get(PostMutationService);
     postRepository = dataSource.getRepository(Post);
     postLikeRepository = dataSource.getRepository(PostLike);
     attachmentRepository = dataSource.getRepository(Attachment);
@@ -136,7 +135,7 @@ describe("PostService", () => {
       const a2 = await saveTestAttachment(attachmentRepository);
 
       // When: 글 생성 시도
-      const post = await postService.createPost({
+      const post = await postMutationService.createPost({
         userId: user.id,
         content: "hello",
         nickname: "nick",
@@ -161,7 +160,7 @@ describe("PostService", () => {
       const nonExistentAttachmentId = 0;
 
       // When: 글 생성 시도
-      const result = postService.createPost({
+      const result = postMutationService.createPost({
         userId: user.id,
         content: "hello",
         nickname: "nick",
@@ -181,7 +180,7 @@ describe("PostService", () => {
       });
 
       // When: 글 생성 시도
-      const result = postService.createPost({
+      const result = postMutationService.createPost({
         userId: user.id,
         content: "hello",
         nickname: "nick",
@@ -203,7 +202,7 @@ describe("PostService", () => {
       });
 
       // When: 글 생성 시도
-      const result = postService.createPost({
+      const result = postMutationService.createPost({
         userId: user.id,
         content: "hello",
         nickname: "nick",
@@ -214,144 +213,6 @@ describe("PostService", () => {
       // Then: throws handled error, 글 생성되지 않음
       await expect(result).rejects.toThrow(AttachmentAlreadyAssociatedError);
       expect(await postRepository.count()).toBe(1); // only the existing post
-    });
-  });
-
-  describe("listPosts", () => {
-    // 2026-03-23: success 처리를 parameter의 조합별로 더 테스트하는 것이 더
-    // 엄밀하지만, 현재는 그럴 필요가 없다고 판단하여 success 케이스 하나만
-    // 처리합니다.
-    it("success: 각 parameter 처리", async () => {
-      // Given: posts
-      const user = await saveTestUser(userRepository);
-      const p1 = await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY1,
-      });
-      const p2 = await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY1,
-      });
-      const p3 = await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY1,
-      });
-      await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY2,
-      });
-
-      // When: 글 조회 시도
-      const result = await postService.listPosts({
-        limit: 2,
-        category: PostCategory.DUMMY1,
-        orderBy: "createdAt",
-        orderDirection: "asc",
-      });
-
-      // Then: 올바른 결과 반환
-      expect(result.posts.map((p) => p.id)).toEqual([p1.id, p2.id]);
-      expect(result.nextCursor).toBeDefined();
-
-      // When: nextCursor로 글 조회 시도
-      const result2 = await postService.listPosts({
-        cursor: result.nextCursor,
-        limit: 2,
-        category: PostCategory.DUMMY1,
-        orderBy: "createdAt",
-        orderDirection: "asc",
-      });
-
-      // Then: 올바른 결과 반환
-      expect(result2.posts.map((p) => p.id)).toEqual([p3.id]);
-      expect(result2.nextCursor).toBeUndefined();
-    });
-
-    it("success: cursor에 해당하는 글이 삭제된 경우 올바르게 처리", async () => {
-      // Given: cursor에 해당하는 글이 삭제된 경우
-      const user = await saveTestUser(userRepository);
-      const p1 = await saveTestPost(postRepository, user.id);
-      const p2 = await saveTestPost(postRepository, user.id);
-      const p3 = await saveTestPost(postRepository, user.id);
-
-      const firstPage = await postService.listPosts({
-        limit: 1,
-        orderBy: "createdAt",
-        orderDirection: "asc",
-      });
-      await postRepository.delete(p1.id);
-
-      // When: 글 조회 시도
-      const result = await postService.listPosts({
-        cursor: firstPage.nextCursor,
-        limit: 2,
-        orderBy: "createdAt",
-        orderDirection: "asc",
-      });
-
-      // Then: 삭제된 글 다음부터 올바르게 반환
-      expect(result.posts.map((p) => p.id)).toEqual([p2.id, p3.id]);
-    });
-
-    it("category 및 orderBy와 벗어난 cursor 처리", async () => {
-      // Given: cursor가 category 및 orderBy를 다르게 하여 조회했을 때의
-      // 결과물인 경우
-      const user = await saveTestUser(userRepository);
-      await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY1,
-      });
-      await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY1,
-      });
-      const firstPage = await postService.listPosts({
-        limit: 1,
-        orderBy: "createdAt",
-        orderDirection: "asc",
-        category: PostCategory.DUMMY1,
-      });
-
-      // When: 글 조회 시도
-      const result = postService.listPosts({
-        cursor: firstPage.nextCursor,
-        limit: 1,
-        orderBy: "createdAt",
-        orderDirection: "asc",
-        category: PostCategory.DUMMY2,
-      });
-
-      // Then: throws handled error
-      await expect(result).rejects.toThrow(InvalidCursorError);
-    });
-  });
-
-  describe("getPost", () => {
-    it("success: 올바른 글 반환", async () => {
-      // Given: 글이 존재하는 경우
-      const user = await saveTestUser(userRepository);
-      const post = await postRepository.save(
-        postRepository.create({
-          content: "hello world",
-          category: PostCategory.DUMMY1,
-          nickname: "testnick",
-          author: user,
-        }),
-      );
-
-      // When: 글 조회 시도
-      const result = await postService.getPost(post.id);
-
-      // Then: 올바른 글 반환
-      expect(result).toMatchObject({
-        id: post.id,
-        content: "hello world",
-        category: PostCategory.DUMMY1,
-      });
-    });
-
-    it("존재하지 않는 글 처리", async () => {
-      // Given: 글이 존재하지 않는 경우
-
-      // When: 글 조회 시도
-      const result = postService.getPost(0);
-
-      // Then: throws handled error
-      await expect(result).rejects.toThrow(PostNotFoundError);
     });
   });
 
@@ -369,7 +230,7 @@ describe("PostService", () => {
       const newAttachment = await saveTestAttachment(attachmentRepository);
 
       // When: 글 업데이트 시도
-      await postService.updatePost({
+      await postMutationService.updatePost({
         userId: user.id,
         postId: post.id,
         content: "updated content",
@@ -401,7 +262,7 @@ describe("PostService", () => {
       // Given: 글이 존재하지 않는 경우
 
       // When: 글 업데이트 시도
-      const result = postService.updatePost({
+      const result = postMutationService.updatePost({
         userId: 0,
         postId: 0,
         content: "content",
@@ -420,7 +281,7 @@ describe("PostService", () => {
       const post = await saveTestPost(postRepository, author.id);
 
       // When: 글 업데이트 시도
-      const result = postService.updatePost({
+      const result = postMutationService.updatePost({
         userId: otherUser.id,
         postId: post.id,
         content: "content",
@@ -441,7 +302,7 @@ describe("PostService", () => {
       const nonExistentAttachmentId = 0;
 
       // When: 글 업데이트 시도
-      const result = postService.updatePost({
+      const result = postMutationService.updatePost({
         userId: user.id,
         postId: post.id,
         content: "content",
@@ -464,7 +325,7 @@ describe("PostService", () => {
       });
 
       // When: 글 업데이트 시도
-      const result = postService.updatePost({
+      const result = postMutationService.updatePost({
         userId: user.id,
         postId: post.id,
         content: "content",
@@ -488,7 +349,7 @@ describe("PostService", () => {
       });
 
       // When: 글 업데이트 시도
-      const result = postService.updatePost({
+      const result = postMutationService.updatePost({
         userId: user.id,
         postId: post.id,
         content: "content",
@@ -508,7 +369,7 @@ describe("PostService", () => {
       const post = await saveTestPost(postRepository, user.id);
 
       // When: liked를 true로 지정하여 요청
-      await postService.setPostLike(user.id, post.id, true);
+      await postMutationService.setPostLike(user.id, post.id, true);
 
       // Then: post like entity 생성, likeCount 업데이트
       const like = await postLikeRepository.findOneBy({
@@ -536,7 +397,7 @@ describe("PostService", () => {
       );
 
       // When: liked를 true로 지정하여 요청
-      await postService.setPostLike(user.id, post.id, true);
+      await postMutationService.setPostLike(user.id, post.id, true);
 
       // Then: post like entity 유지, likeCount 유지
       const like = await postLikeRepository.findOne({
@@ -561,7 +422,7 @@ describe("PostService", () => {
       );
 
       // When: liked를 false로 지정하여 요청
-      await postService.setPostLike(user.id, post.id, false);
+      await postMutationService.setPostLike(user.id, post.id, false);
 
       // Then: post like entity 삭제, likeCount 업데이트
       const like = await postLikeRepository.findOne({
@@ -578,7 +439,7 @@ describe("PostService", () => {
       const post = await saveTestPost(postRepository, user.id);
 
       // When: liked를 false로 지정하여 요청
-      await postService.setPostLike(user.id, post.id, false);
+      await postMutationService.setPostLike(user.id, post.id, false);
 
       // Then: post like entity 없음 유지, likeCount 유지
       const like = await postLikeRepository.findOne({
@@ -594,7 +455,7 @@ describe("PostService", () => {
       const user = await saveTestUser(userRepository);
 
       // When: liked 요청 시도
-      const result = postService.setPostLike(user.id, 0, true);
+      const result = postMutationService.setPostLike(user.id, 0, true);
 
       // Then: throws handled error
       await expect(result).rejects.toThrow(PostNotFoundError);
@@ -612,7 +473,7 @@ describe("PostService", () => {
       fakeS3.put(attachment.s3Key);
 
       // When: 글 삭제 시도
-      await postService.deletePost(user.id, post.id);
+      await postMutationService.deletePost(user.id, post.id);
 
       // Then: 글 및 attachments 삭제됨
       expect(await postRepository.findOneBy({ id: post.id })).toBeNull();
@@ -627,7 +488,7 @@ describe("PostService", () => {
       const user = await saveTestUser(userRepository);
 
       // When: 글 삭제 시도
-      const result = postService.deletePost(user.id, 0);
+      const result = postMutationService.deletePost(user.id, 0);
 
       // Then: throws handled error
       await expect(result).rejects.toThrow(PostNotFoundError);
@@ -640,7 +501,7 @@ describe("PostService", () => {
       const post = await saveTestPost(postRepository, otherUser.id);
 
       // When: 글 삭제 시도
-      const result = postService.deletePost(user.id, post.id);
+      const result = postMutationService.deletePost(user.id, post.id);
 
       // Then: throws handled error
       await expect(result).rejects.toThrow(NotPostAuthorError);

--- a/apps/backend/src/post/post-mutation.service.ts
+++ b/apps/backend/src/post/post-mutation.service.ts
@@ -133,11 +133,11 @@ export class PostMutationService {
     postId: number,
     liked: boolean,
   ): Promise<void> {
-    const existingPost = await this.postRepository.findOneBy({
+    const postExists = await this.postRepository.existsBy({
       id: postId,
     });
 
-    if (!existingPost) {
+    if (!postExists) {
       throw new PostNotFoundError();
     }
 
@@ -151,8 +151,7 @@ export class PostMutationService {
       const postRepository = manager.getRepository(Post);
 
       if (liked && !postLikeExists) {
-        existingPost.likeCount++;
-        await postRepository.save(existingPost);
+        await postRepository.increment({ id: postId }, "likeCount", 1);
 
         await postLikeRepository.save(
           this.postLikeRepository.create({
@@ -163,8 +162,7 @@ export class PostMutationService {
       }
 
       if (!liked && postLikeExists) {
-        existingPost.likeCount--;
-        await postRepository.save(existingPost);
+        await postRepository.decrement({ id: postId }, "likeCount", 1);
 
         await postLikeRepository.delete({
           user: { id: userId },

--- a/apps/backend/src/post/post-mutation.service.ts
+++ b/apps/backend/src/post/post-mutation.service.ts
@@ -8,7 +8,6 @@ import { S3StorageService } from "src/s3-storage/s3-storage.service";
 import {
   AttachmentAlreadyAssociatedError,
   AttachmentNotFoundError,
-  InvalidCursorError,
   NotPostAuthorError,
   PostNotFoundError,
 } from "./post.errors";
@@ -21,21 +20,6 @@ export type CreatePostOptions = {
   attachmentIds: number[];
 };
 
-export type ListPostsOrderBy = "createdAt";
-
-export type ListPostsOptions = {
-  cursor?: string;
-  limit: number;
-  category?: PostCategory;
-  orderBy: ListPostsOrderBy;
-  orderDirection: "asc" | "desc";
-};
-
-export type ListPostsResult = {
-  posts: Post[];
-  nextCursor?: string;
-};
-
 export type UpdatePostOptions = {
   userId: number;
   postId: number;
@@ -44,45 +28,11 @@ export type UpdatePostOptions = {
   attachmentIds: number[];
 };
 
-type CursorPayload = {
-  category: PostCategory | null;
-  orderBy: ListPostsOrderBy;
-  orderDirection: "asc" | "desc";
-  cursorValue: string;
-  cursorId: number;
-};
-
-function encodeCursor(payload: CursorPayload): string {
-  return Buffer.from(JSON.stringify(payload)).toString("base64url");
-}
-
-function decodeCursor(cursor: string): CursorPayload {
-  return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
-}
-
-// 2026-03-25 code smell....
-const orderByMap: Record<
-  ListPostsOrderBy,
-  {
-    path: string;
-    column: string;
-    cast: string;
-    getValue: (post: Post) => string;
-  }
-> = {
-  createdAt: {
-    path: "post.createdAt",
-    column: 'extract(epoch FROM "post"."created_at")::int',
-    cast: "extract(epoch FROM :cursorValue)::int",
-    getValue: (post) => post.createdAt.toISOString(),
-  },
-};
-
 /**
- * PostController와 1:1로 대응되는, post 관련 orchestration logic을 담당한다.
+ * controller에서 사용하기 위한 글의 mutation을 담당한다.
  */
 @Injectable()
-export class PostService {
+export class PostMutationService {
   constructor(
     @InjectRepository(Post)
     private readonly postRepository: Repository<Post>,
@@ -118,86 +68,6 @@ export class PostService {
       }),
     );
 
-    return post;
-  }
-
-  /*
-   * pagination option을 적용하여 글 목록을 조회한다.
-   * @returns 글 목록, attachment URL, cursor
-   */
-  async listPosts({
-    limit,
-    orderBy,
-    orderDirection,
-    category,
-    cursor,
-  }: ListPostsOptions): Promise<ListPostsResult> {
-    const decodedCursor = cursor && decodeCursor(cursor);
-
-    if (
-      decodedCursor &&
-      (category != decodedCursor.category || // != for null-undefined checks
-        orderBy !== decodedCursor.orderBy ||
-        orderDirection !== decodedCursor.orderDirection)
-    ) {
-      throw new InvalidCursorError();
-    }
-
-    const sqlDirection = orderDirection === "asc" ? "ASC" : "DESC";
-    const cursorOp = orderDirection === "asc" ? ">" : "<";
-    const orderEntry = orderByMap[orderBy];
-
-    const qb = this.postRepository.createQueryBuilder("post");
-
-    if (category) {
-      qb.where("post.category = :category", { category });
-    }
-
-    if (decodedCursor) {
-      qb.andWhere(
-        [
-          `(${orderEntry.column}, "post"."id")`,
-          cursorOp,
-          `(${orderEntry.cast}, :cursorId::int)`,
-        ].join(""),
-        {
-          cursorValue: decodedCursor.cursorValue,
-          cursorId: decodedCursor.cursorId,
-        },
-      );
-    }
-
-    const posts = await qb
-      .orderBy(orderEntry.path, sqlDirection)
-      .addOrderBy("post.id", sqlDirection)
-      .limit(limit)
-      .getMany();
-
-    const lastPost = posts.at(-1)!;
-    return {
-      posts,
-      nextCursor:
-        posts.length === limit
-          ? encodeCursor({
-              orderBy,
-              orderDirection,
-              category: category ?? null,
-              cursorId: lastPost.id,
-              cursorValue: orderEntry.getValue(lastPost),
-            })
-          : undefined,
-    };
-  }
-
-  /**
-   * postId에 대응하는 글 하나를 조회한다.
-   * @returns 해당 글, attachment URL
-   */
-  async getPost(postId: number): Promise<Post> {
-    const post = await this.postRepository.findOneBy({ id: postId });
-    if (!post) {
-      throw new PostNotFoundError();
-    }
     return post;
   }
 
@@ -251,7 +121,7 @@ export class PostService {
     });
 
     await this.s3StorageService.deleteMany(
-      post.attachments.map((a) => a.s3Key),
+      deletingAttachments.map((a) => a.s3Key),
     );
   }
 
@@ -305,7 +175,7 @@ export class PostService {
   }
 
   /**
-   * userId에 대응하는 사용자가 글의 작성자인 경우, 글을 삭제한다.2
+   * userId에 대응하는 사용자가 글의 작성자인 경우, 글을 삭제한다.
    */
   async deletePost(userId: number, postId: number): Promise<void> {
     const post = await this.postRepository.findOne({

--- a/apps/backend/src/post/post-query.service.spec.ts
+++ b/apps/backend/src/post/post-query.service.spec.ts
@@ -1,0 +1,223 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { DataSource, Repository } from "typeorm";
+import PGMem from "pg-mem";
+import { PostQueryService } from "./post-query.service";
+import { InvalidCursorError, PostNotFoundError } from "./post.errors";
+import { Post, PostCategory } from "./post.entity";
+import { PostLike } from "./post-like.entity";
+import { Attachment } from "../attachment/attachment.entity";
+import { User, UserRole } from "../user/user.entity";
+import { UserProfile } from "../user/user-profile.entity";
+import { initializePgMem } from "src/test/pg-mem.helper";
+
+const entities = [UserProfile, User, Post, PostLike, Attachment];
+
+let userCounter = 0;
+
+async function saveTestUser(
+  repository: Repository<User>,
+  overrides?: Partial<User>,
+): Promise<User> {
+  return repository.save(
+    repository.create({
+      email: `user${++userCounter}@test.com`,
+      password: "password",
+      role: UserRole.USER,
+      ...overrides,
+    }),
+  );
+}
+
+async function saveTestPost(
+  repository: Repository<Post>,
+  userId: number,
+  overrides?: Partial<Post>,
+): Promise<Post> {
+  return repository.save(
+    repository.create({
+      content: "test content",
+      category: PostCategory.DUMMY1,
+      nickname: "testnick",
+      author: { id: userId } as User,
+      ...overrides,
+    }),
+  );
+}
+
+describe("PostQueryService", () => {
+  let module: TestingModule;
+  let postQueryService: PostQueryService;
+  let postRepository: Repository<Post>;
+  let userRepository: Repository<User>;
+  let dataSource: DataSource;
+  let dbBackup: PGMem.IBackup;
+
+  beforeAll(async () => {
+    const { dataSource: ds, backup } = await initializePgMem(entities);
+    dataSource = ds;
+    dbBackup = backup;
+
+    module = await Test.createTestingModule({
+      providers: [
+        PostQueryService,
+        {
+          provide: getRepositoryToken(Post),
+          useValue: dataSource.getRepository(Post),
+        },
+      ],
+    }).compile();
+
+    postQueryService = module.get(PostQueryService);
+    postRepository = dataSource.getRepository(Post);
+    userRepository = dataSource.getRepository(User);
+  });
+
+  beforeEach(() => {
+    dbBackup.restore();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+    await module.close();
+  });
+
+  describe("listPosts", () => {
+    // 2026-03-23: success 처리를 parameter의 조합별로 더 테스트하는 것이 더
+    // 엄밀하지만, 현재는 그럴 필요가 없다고 판단하여 success 케이스 하나만
+    // 처리합니다.
+    it("success: 각 parameter 처리", async () => {
+      // Given: posts
+      const user = await saveTestUser(userRepository);
+      const p1 = await saveTestPost(postRepository, user.id, {
+        category: PostCategory.DUMMY1,
+      });
+      const p2 = await saveTestPost(postRepository, user.id, {
+        category: PostCategory.DUMMY1,
+      });
+      const p3 = await saveTestPost(postRepository, user.id, {
+        category: PostCategory.DUMMY1,
+      });
+      await saveTestPost(postRepository, user.id, {
+        category: PostCategory.DUMMY2,
+      });
+
+      // When: 글 조회 시도
+      const result = await postQueryService.listPosts({
+        limit: 2,
+        category: PostCategory.DUMMY1,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+
+      // Then: 올바른 결과 반환
+      expect(result.posts.map((p) => p.id)).toEqual([p1.id, p2.id]);
+      expect(result.nextCursor).toBeDefined();
+
+      // When: nextCursor로 글 조회 시도
+      const result2 = await postQueryService.listPosts({
+        cursor: result.nextCursor,
+        limit: 2,
+        category: PostCategory.DUMMY1,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+
+      // Then: 올바른 결과 반환
+      expect(result2.posts.map((p) => p.id)).toEqual([p3.id]);
+      expect(result2.nextCursor).toBeUndefined();
+    });
+
+    it("success: cursor에 해당하는 글이 삭제된 경우 올바르게 처리", async () => {
+      // Given: cursor에 해당하는 글이 삭제된 경우
+      const user = await saveTestUser(userRepository);
+      const p1 = await saveTestPost(postRepository, user.id);
+      const p2 = await saveTestPost(postRepository, user.id);
+      const p3 = await saveTestPost(postRepository, user.id);
+
+      const firstPage = await postQueryService.listPosts({
+        limit: 1,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+      await postRepository.delete(p1.id);
+
+      // When: 글 조회 시도
+      const result = await postQueryService.listPosts({
+        cursor: firstPage.nextCursor,
+        limit: 2,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+
+      // Then: 삭제된 글 다음부터 올바르게 반환
+      expect(result.posts.map((p) => p.id)).toEqual([p2.id, p3.id]);
+    });
+
+    it("category 및 orderBy와 벗어난 cursor 처리", async () => {
+      // Given: cursor가 category 및 orderBy를 다르게 하여 조회했을 때의
+      // 결과물인 경우
+      const user = await saveTestUser(userRepository);
+      await saveTestPost(postRepository, user.id, {
+        category: PostCategory.DUMMY1,
+      });
+      await saveTestPost(postRepository, user.id, {
+        category: PostCategory.DUMMY1,
+      });
+      const firstPage = await postQueryService.listPosts({
+        limit: 1,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+        category: PostCategory.DUMMY1,
+      });
+
+      // When: 글 조회 시도
+      const result = postQueryService.listPosts({
+        cursor: firstPage.nextCursor,
+        limit: 1,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+        category: PostCategory.DUMMY2,
+      });
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(InvalidCursorError);
+    });
+  });
+
+  describe("getPost", () => {
+    it("success: 올바른 글 반환", async () => {
+      // Given: 글이 존재하는 경우
+      const user = await saveTestUser(userRepository);
+      const post = await postRepository.save(
+        postRepository.create({
+          content: "hello world",
+          category: PostCategory.DUMMY1,
+          nickname: "testnick",
+          author: user,
+        }),
+      );
+
+      // When: 글 조회 시도
+      const result = await postQueryService.getPost(post.id);
+
+      // Then: 올바른 글 반환
+      expect(result).toMatchObject({
+        id: post.id,
+        content: "hello world",
+        category: PostCategory.DUMMY1,
+      });
+    });
+
+    it("존재하지 않는 글 처리", async () => {
+      // Given: 글이 존재하지 않는 경우
+
+      // When: 글 조회 시도
+      const result = postQueryService.getPost(0);
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(PostNotFoundError);
+    });
+  });
+});

--- a/apps/backend/src/post/post-query.service.spec.ts
+++ b/apps/backend/src/post/post-query.service.spec.ts
@@ -10,6 +10,8 @@ import { Attachment } from "../attachment/attachment.entity";
 import { User, UserRole } from "../user/user.entity";
 import { UserProfile } from "../user/user-profile.entity";
 import { initializePgMem } from "src/test/pg-mem.helper";
+import { S3StorageService } from "src/s3-storage/s3-storage.service";
+import { FakeS3StorageService } from "src/s3-storage/s3-storage.service.fake";
 
 const entities = [UserProfile, User, Post, PostLike, Attachment];
 
@@ -45,11 +47,26 @@ async function saveTestPost(
   );
 }
 
+async function saveTestPosts(
+  repository: Repository<Post>,
+  userId: number,
+  overridesList: Partial<Post>[],
+): Promise<number[]> {
+  const ids: number[] = [];
+  for (const overrides of overridesList) {
+    ids.push((await saveTestPost(repository, userId, overrides)).id);
+  }
+  return ids;
+}
+
 describe("PostQueryService", () => {
   let module: TestingModule;
   let postQueryService: PostQueryService;
   let postRepository: Repository<Post>;
+  let postLikeRepository: Repository<PostLike>;
+  let attachmentRepository: Repository<Attachment>;
   let userRepository: Repository<User>;
+  let fakeS3: FakeS3StorageService;
   let dataSource: DataSource;
   let dbBackup: PGMem.IBackup;
 
@@ -58,6 +75,8 @@ describe("PostQueryService", () => {
     dataSource = ds;
     dbBackup = backup;
 
+    fakeS3 = new FakeS3StorageService();
+
     module = await Test.createTestingModule({
       providers: [
         PostQueryService,
@@ -65,16 +84,28 @@ describe("PostQueryService", () => {
           provide: getRepositoryToken(Post),
           useValue: dataSource.getRepository(Post),
         },
+        {
+          provide: getRepositoryToken(PostLike),
+          useValue: dataSource.getRepository(PostLike),
+        },
+        {
+          provide: getRepositoryToken(Attachment),
+          useValue: dataSource.getRepository(Attachment),
+        },
+        { provide: S3StorageService, useValue: fakeS3 },
       ],
     }).compile();
 
     postQueryService = module.get(PostQueryService);
     postRepository = dataSource.getRepository(Post);
+    postLikeRepository = dataSource.getRepository(PostLike);
+    attachmentRepository = dataSource.getRepository(Attachment);
     userRepository = dataSource.getRepository(User);
   });
 
   beforeEach(() => {
     dbBackup.restore();
+    fakeS3.reset();
     jest.restoreAllMocks();
   });
 
@@ -84,110 +115,201 @@ describe("PostQueryService", () => {
   });
 
   describe("listPosts", () => {
-    // 2026-03-23: success 처리를 parameter의 조합별로 더 테스트하는 것이 더
-    // 엄밀하지만, 현재는 그럴 필요가 없다고 판단하여 success 케이스 하나만
-    // 처리합니다.
-    it("success: 각 parameter 처리", async () => {
-      // Given: posts
-      const user = await saveTestUser(userRepository);
-      const p1 = await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY1,
-      });
-      const p2 = await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY1,
-      });
-      const p3 = await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY1,
-      });
-      await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY2,
+    describe("pagination", () => {
+      // 2026-03-23: success 처리를 parameter의 조합별로 더 테스트하는 것이 더
+      // 엄밀하지만, 현재는 그럴 필요가 없다고 판단하여 success 케이스 하나만
+      // 처리합니다.
+      it("success: 각 parameter 처리", async () => {
+        // Given: posts
+        const user = await saveTestUser(userRepository);
+        const ids = await saveTestPosts(postRepository, user.id, [
+          { category: PostCategory.DUMMY1 },
+          { category: PostCategory.DUMMY1 },
+          { category: PostCategory.DUMMY1 },
+          { category: PostCategory.DUMMY2 },
+        ]);
+
+        // When: 글 조회 시도
+        const result = await postQueryService.listPosts(user.id, {
+          limit: 2,
+          category: PostCategory.DUMMY1,
+          orderBy: "createdAt",
+          orderDirection: "asc",
+        });
+
+        // Then: 올바른 결과 반환
+        expect(result.entries.map((p) => p.post.id)).toEqual([ids[0], ids[1]]);
+        expect(result.nextCursor).toBeDefined();
+
+        // When: nextCursor로 글 조회 시도
+        const result2 = await postQueryService.listPosts(user.id, {
+          cursor: result.nextCursor,
+          limit: 2,
+          category: PostCategory.DUMMY1,
+          orderBy: "createdAt",
+          orderDirection: "asc",
+        });
+
+        // Then: 올바른 결과 반환
+        expect(result2.entries.map((p) => p.post.id)).toEqual([ids[2]]);
+        expect(result2.nextCursor).toBeUndefined();
       });
 
-      // When: 글 조회 시도
-      const result = await postQueryService.listPosts({
-        limit: 2,
-        category: PostCategory.DUMMY1,
-        orderBy: "createdAt",
-        orderDirection: "asc",
+      it("success: cursor에 해당하는 글이 삭제된 경우 올바르게 처리", async () => {
+        // Given: cursor에 해당하는 글이 삭제된 경우
+        const user = await saveTestUser(userRepository);
+        const ids = await saveTestPosts(postRepository, user.id, [{}, {}, {}]);
+
+        const firstPage = await postQueryService.listPosts(user.id, {
+          limit: 1,
+          orderBy: "createdAt",
+          orderDirection: "asc",
+        });
+        await postRepository.delete(ids[0]);
+
+        // When: 글 조회 시도
+        const result = await postQueryService.listPosts(user.id, {
+          cursor: firstPage.nextCursor,
+          limit: 2,
+          orderBy: "createdAt",
+          orderDirection: "asc",
+        });
+
+        // Then: 삭제된 글 다음부터 올바르게 반환
+        expect(result.entries.map((p) => p.post.id)).toEqual([ids[1], ids[2]]);
       });
 
-      // Then: 올바른 결과 반환
-      expect(result.posts.map((p) => p.id)).toEqual([p1.id, p2.id]);
-      expect(result.nextCursor).toBeDefined();
+      it("category 및 orderBy와 벗어난 cursor 처리", async () => {
+        // Given: cursor가 category 및 orderBy를 다르게 하여 조회했을 때의
+        // 결과물인 경우
+        const user = await saveTestUser(userRepository);
+        await saveTestPosts(postRepository, user.id, [
+          { category: PostCategory.DUMMY1 },
+          { category: PostCategory.DUMMY1 },
+        ]);
+        const firstPage = await postQueryService.listPosts(user.id, {
+          limit: 1,
+          orderBy: "createdAt",
+          orderDirection: "asc",
+          category: PostCategory.DUMMY1,
+        });
 
-      // When: nextCursor로 글 조회 시도
-      const result2 = await postQueryService.listPosts({
-        cursor: result.nextCursor,
-        limit: 2,
-        category: PostCategory.DUMMY1,
-        orderBy: "createdAt",
-        orderDirection: "asc",
+        // When: 글 조회 시도
+        const result = postQueryService.listPosts(user.id, {
+          cursor: firstPage.nextCursor,
+          limit: 1,
+          orderBy: "createdAt",
+          orderDirection: "asc",
+          category: PostCategory.DUMMY2,
+        });
+
+        // Then: throws handled error
+        await expect(result).rejects.toThrow(InvalidCursorError);
       });
-
-      // Then: 올바른 결과 반환
-      expect(result2.posts.map((p) => p.id)).toEqual([p3.id]);
-      expect(result2.nextCursor).toBeUndefined();
     });
 
-    it("success: cursor에 해당하는 글이 삭제된 경우 올바르게 처리", async () => {
-      // Given: cursor에 해당하는 글이 삭제된 경우
-      const user = await saveTestUser(userRepository);
-      const p1 = await saveTestPost(postRepository, user.id);
-      const p2 = await saveTestPost(postRepository, user.id);
-      const p3 = await saveTestPost(postRepository, user.id);
+    describe("relation fields", () => {
+      it("success: user가 owner -> isOwner true", async () => {
+        // Given: 사용자 및 글 (테스트를 위해 단일로만 저장)
+        const user = await saveTestUser(userRepository);
+        await saveTestPost(postRepository, user.id);
 
-      const firstPage = await postQueryService.listPosts({
-        limit: 1,
-        orderBy: "createdAt",
-        orderDirection: "asc",
-      });
-      await postRepository.delete(p1.id);
+        // When: 글 목록 조회 시도
+        const result = await postQueryService.listPosts(user.id, {
+          limit: 1,
+          orderBy: "createdAt",
+          orderDirection: "asc",
+        });
 
-      // When: 글 조회 시도
-      const result = await postQueryService.listPosts({
-        cursor: firstPage.nextCursor,
-        limit: 2,
-        orderBy: "createdAt",
-        orderDirection: "asc",
+        // Then: isOwner === true
+        expect(result.entries[0].withUser.isOwner).toBe(true);
       });
 
-      // Then: 삭제된 글 다음부터 올바르게 반환
-      expect(result.posts.map((p) => p.id)).toEqual([p2.id, p3.id]);
+      it("success: user가 owner 아님 -> isOwner false", async () => {
+        // Given: 글 작성자와 다른 사용자
+        const author = await saveTestUser(userRepository);
+        const viewer = await saveTestUser(userRepository);
+        await saveTestPost(postRepository, author.id);
+
+        // When: viewer로 글 목록 조회 시도
+        const result = await postQueryService.listPosts(viewer.id, {
+          limit: 1,
+          orderBy: "createdAt",
+          orderDirection: "asc",
+        });
+
+        // Then: isOwner === false
+        expect(result.entries[0].withUser.isOwner).toBe(false);
+      });
+
+      it("success: user가 like한 글 -> isLiked true", async () => {
+        // Given: user가 like한 글
+        const user = await saveTestUser(userRepository);
+        const post = await saveTestPost(postRepository, user.id);
+        await postLikeRepository.save(
+          postLikeRepository.create({
+            user: { id: user.id },
+            post: { id: post.id },
+          }),
+        );
+
+        // When: 글 목록 조회 시도
+        const result = await postQueryService.listPosts(user.id, {
+          limit: 1,
+          orderBy: "createdAt",
+          orderDirection: "asc",
+        });
+
+        // Then: isLiked === true
+        expect(result.entries[0].withUser.isLiked).toBe(true);
+      });
+
+      it("success: user가 like 하지 않은 글 -> isLiked false", async () => {
+        // Given: user가 like하지 않은 글
+        const user = await saveTestUser(userRepository);
+        await saveTestPost(postRepository, user.id);
+
+        // When: 글 목록 조회 시도
+        const result = await postQueryService.listPosts(user.id, {
+          limit: 1,
+          orderBy: "createdAt",
+          orderDirection: "asc",
+        });
+
+        // Then: isLiked === false
+        expect(result.entries[0].withUser.isLiked).toBe(false);
+      });
     });
 
-    it("category 및 orderBy와 벗어난 cursor 처리", async () => {
-      // Given: cursor가 category 및 orderBy를 다르게 하여 조회했을 때의
-      // 결과물인 경우
+    it("success: 올바른 attachments URL 맵 반환", async () => {
+      // Given: attachment가 있는 글
       const user = await saveTestUser(userRepository);
-      await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY1,
-      });
-      await saveTestPost(postRepository, user.id, {
-        category: PostCategory.DUMMY1,
-      });
-      const firstPage = await postQueryService.listPosts({
+      const post = await saveTestPost(postRepository, user.id);
+      const attachment = await attachmentRepository.save(
+        attachmentRepository.create({
+          confirmed: true,
+          s3Key: "attachments/test-key",
+          index: 0,
+          post,
+        }),
+      );
+
+      // When: 글 목록 조회 시도
+      const result = await postQueryService.listPosts(user.id, {
         limit: 1,
         orderBy: "createdAt",
         orderDirection: "asc",
-        category: PostCategory.DUMMY1,
       });
 
-      // When: 글 조회 시도
-      const result = postQueryService.listPosts({
-        cursor: firstPage.nextCursor,
-        limit: 1,
-        orderBy: "createdAt",
-        orderDirection: "asc",
-        category: PostCategory.DUMMY2,
-      });
-
-      // Then: throws handled error
-      await expect(result).rejects.toThrow(InvalidCursorError);
+      // Then: attachment URL 맵 올바르게 반환
+      expect(result.attachmentToUrl[attachment.id]).toBe(
+        fakeS3.getPublicUrl(attachment.s3Key),
+      );
     });
   });
 
   describe("getPost", () => {
-    it("success: 올바른 글 반환", async () => {
+    it("success: 올바른 fields 반환", async () => {
       // Given: 글이 존재하는 경우
       const user = await saveTestUser(userRepository);
       const post = await postRepository.save(
@@ -200,21 +322,102 @@ describe("PostQueryService", () => {
       );
 
       // When: 글 조회 시도
-      const result = await postQueryService.getPost(post.id);
+      const result = await postQueryService.getPost(user.id, post.id);
 
       // Then: 올바른 글 반환
-      expect(result).toMatchObject({
+      expect(result.entry.post).toMatchObject({
         id: post.id,
         content: "hello world",
         category: PostCategory.DUMMY1,
       });
     });
 
-    it("존재하지 않는 글 처리", async () => {
-      // Given: 글이 존재하지 않는 경우
+    describe("relation fields", () => {
+      it("success: user가 owner -> isOwner true", async () => {
+        // Given: 글 작성자
+        const user = await saveTestUser(userRepository);
+        const post = await saveTestPost(postRepository, user.id);
+
+        // When: 글 조회 시도
+        const result = await postQueryService.getPost(user.id, post.id);
+
+        // Then: isOwner === true
+        expect(result.entry.withUser.isOwner).toBe(true);
+      });
+
+      it("success: user가 owner 아님 -> isOwner false", async () => {
+        // Given: 글 작성자와 다른 사용자
+        const author = await saveTestUser(userRepository);
+        const viewer = await saveTestUser(userRepository);
+        const post = await saveTestPost(postRepository, author.id);
+
+        // When: viewer로 글 조회 시도
+        const result = await postQueryService.getPost(viewer.id, post.id);
+
+        // Then: isOwner === false
+        expect(result.entry.withUser.isOwner).toBe(false);
+      });
+
+      it("success: user가 like한 글 -> isLiked true", async () => {
+        // Given: user가 like한 글
+        const user = await saveTestUser(userRepository);
+        const post = await saveTestPost(postRepository, user.id);
+        await postLikeRepository.save(
+          postLikeRepository.create({
+            user: { id: user.id },
+            post: { id: post.id },
+          }),
+        );
+
+        // When: 글 조회 시도
+        const result = await postQueryService.getPost(user.id, post.id);
+
+        // Then: isLiked === true
+        expect(result.entry.withUser.isLiked).toBe(true);
+      });
+
+      it("success: user가 like 하지 않은 글 -> isLiked false", async () => {
+        // Given: user가 like하지 않은 글
+        const user = await saveTestUser(userRepository);
+        const post = await saveTestPost(postRepository, user.id);
+
+        // When: 글 조회 시도
+        const result = await postQueryService.getPost(user.id, post.id);
+
+        // Then: isLiked === false
+        expect(result.entry.withUser.isLiked).toBe(false);
+      });
+    });
+
+    it("success: 올바른 attachments URL 맵 반환", async () => {
+      // Given: attachment가 있는 글
+      const user = await saveTestUser(userRepository);
+      const post = await saveTestPost(postRepository, user.id);
+      const attachment = await attachmentRepository.save(
+        attachmentRepository.create({
+          confirmed: true,
+          s3Key: "attachments/test-key",
+          index: 0,
+          post,
+        }),
+      );
 
       // When: 글 조회 시도
-      const result = postQueryService.getPost(0);
+      const result = await postQueryService.getPost(user.id, post.id);
+
+      // Then: attachment URL 맵 올바르게 반환
+      expect(result.attachmentToUrl[attachment.id]).toBe(
+        fakeS3.getPublicUrl(attachment.s3Key),
+      );
+    });
+
+    it("존재하지 않는 글 처리", async () => {
+      // Given: 글이 존재하지 않는 경우
+      const user = await saveTestUser(userRepository);
+      const nonExistentId = 0;
+
+      // When: 글 조회 시도
+      const result = postQueryService.getPost(user.id, nonExistentId);
 
       // Then: throws handled error
       await expect(result).rejects.toThrow(PostNotFoundError);

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -92,7 +92,6 @@ export class PostQueryService {
     private readonly postRepository: Repository<Post>,
     @InjectRepository(PostLike)
     private readonly postLikeRepository: Repository<PostLike>,
-    @InjectRepository(Attachment)
     private readonly s3StorageService: S3StorageService,
   ) {}
 

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -56,6 +56,7 @@ function encodeCursor(payload: CursorPayload): string {
   return Buffer.from(JSON.stringify(payload)).toString("base64url");
 }
 
+// FIXME: structural validation for cursor value
 function decodeCursor(cursor: string): CursorPayload {
   try {
     return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
@@ -150,7 +151,7 @@ export class PostQueryService {
     const posts = await qb
       .orderBy(orderEntry.path, sqlDirection)
       .addOrderBy("post.id", sqlDirection)
-      .limit(limit)
+      .take(limit)
       .getMany();
 
     const postIds = posts.map((p) => p.id);

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -1,0 +1,145 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Post, PostCategory } from "./post.entity";
+import { InvalidCursorError, PostNotFoundError } from "./post.errors";
+
+export type ListPostsOrderBy = "createdAt";
+
+export type ListPostsOptions = {
+  cursor?: string;
+  limit: number;
+  category?: PostCategory;
+  orderBy: ListPostsOrderBy;
+  orderDirection: "asc" | "desc";
+};
+
+export type ListPostsResult = {
+  posts: Post[];
+  nextCursor?: string;
+};
+
+type CursorPayload = {
+  category: PostCategory | null;
+  orderBy: ListPostsOrderBy;
+  orderDirection: "asc" | "desc";
+  cursorValue: string;
+  cursorId: number;
+};
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+function decodeCursor(cursor: string): CursorPayload {
+  return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+}
+
+// 2026-03-25 code smell....
+const orderByMap: Record<
+  ListPostsOrderBy,
+  {
+    path: string;
+    column: string;
+    cast: string;
+    getValue: (post: Post) => string;
+  }
+> = {
+  createdAt: {
+    path: "post.createdAt",
+    column: 'extract(epoch FROM "post"."created_at")::int',
+    cast: "extract(epoch FROM :cursorValue)::int",
+    getValue: (post) => post.createdAt.toISOString(),
+  },
+};
+
+/**
+ * controller에서 사용하기 위한 글의 조회를 담당한다.
+ */
+@Injectable()
+export class PostQueryService {
+  constructor(
+    @InjectRepository(Post)
+    private readonly postRepository: Repository<Post>,
+  ) {}
+
+  /*
+   * pagination option을 적용하여 글 목록을 조회한다.
+   * @returns 글 목록, attachment URL, cursor
+   */
+  async listPosts({
+    limit,
+    orderBy,
+    orderDirection,
+    category,
+    cursor,
+  }: ListPostsOptions): Promise<ListPostsResult> {
+    const decodedCursor = cursor && decodeCursor(cursor);
+
+    if (
+      decodedCursor &&
+      (category != decodedCursor.category || // != for null-undefined checks
+        orderBy !== decodedCursor.orderBy ||
+        orderDirection !== decodedCursor.orderDirection)
+    ) {
+      throw new InvalidCursorError();
+    }
+
+    const sqlDirection = orderDirection === "asc" ? "ASC" : "DESC";
+    const cursorOp = orderDirection === "asc" ? ">" : "<";
+    const orderEntry = orderByMap[orderBy];
+
+    const qb = this.postRepository.createQueryBuilder("post");
+
+    if (category) {
+      qb.where("post.category = :category", { category });
+    }
+
+    if (decodedCursor) {
+      qb.andWhere(
+        [
+          `(${orderEntry.column}, "post"."id")`,
+          cursorOp,
+          `(${orderEntry.cast}, :cursorId::int)`,
+        ].join(""),
+        {
+          cursorValue: decodedCursor.cursorValue,
+          cursorId: decodedCursor.cursorId,
+        },
+      );
+    }
+
+    const posts = await qb
+      .orderBy(orderEntry.path, sqlDirection)
+      .addOrderBy("post.id", sqlDirection)
+      .limit(limit)
+      .getMany();
+
+    const lastPost = posts.at(-1)!;
+    return {
+      posts,
+      nextCursor:
+        posts.length === limit
+          ? encodeCursor({
+              orderBy,
+              orderDirection,
+              category: category ?? null,
+              cursorId: lastPost.id,
+              cursorValue: orderEntry.getValue(lastPost),
+            })
+          : undefined,
+    };
+  }
+
+  /**
+   * postId에 대응하는 글 하나를 조회한다.
+   * @returns 해당 글, attachment URL
+   */
+  async getPost(postId: number): Promise<Post> {
+    const post = await this.postRepository.findOneBy({ id: postId });
+    if (!post) {
+      throw new PostNotFoundError();
+    }
+    return post;
+  }
+}

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -1,12 +1,29 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { In, Repository } from "typeorm";
 import { Post, PostCategory } from "./post.entity";
+import { PostLike } from "./post-like.entity";
+import { Attachment } from "../attachment/attachment.entity";
+import { S3StorageService } from "src/s3-storage/s3-storage.service";
 import { InvalidCursorError, PostNotFoundError } from "./post.errors";
+
+/* shared types */
+
+export type PostWithRelations = {
+  post: Post;
+  withUser: {
+    isOwner: boolean;
+    isLiked: boolean;
+  };
+};
+
+export type AttachmentToUrlMap = Record<number, string>;
 
 export type ListPostsOrderBy = "createdAt";
 
-export type ListPostsOptions = {
+/* listPosts */
+
+export type ListPostsPaginationOptions = {
   cursor?: string;
   limit: number;
   category?: PostCategory;
@@ -15,8 +32,16 @@ export type ListPostsOptions = {
 };
 
 export type ListPostsResult = {
-  posts: Post[];
+  entries: PostWithRelations[];
   nextCursor?: string;
+  attachmentToUrl: AttachmentToUrlMap;
+};
+
+/* getPost */
+
+export type GetPostResult = {
+  entry: PostWithRelations;
+  attachmentToUrl: AttachmentToUrlMap;
 };
 
 type CursorPayload = {
@@ -32,7 +57,11 @@ function encodeCursor(payload: CursorPayload): string {
 }
 
 function decodeCursor(cursor: string): CursorPayload {
-  return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+  try {
+    return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+  } catch {
+    throw new InvalidCursorError();
+  }
 }
 
 // 2026-03-25 code smell....
@@ -48,7 +77,7 @@ const orderByMap: Record<
   createdAt: {
     path: "post.createdAt",
     column: 'extract(epoch FROM "post"."created_at")::int',
-    cast: "extract(epoch FROM :cursorValue)::int",
+    cast: "extract(epoch FROM :cursorValue::timestamp)::int",
     getValue: (post) => post.createdAt.toISOString(),
   },
 };
@@ -61,19 +90,26 @@ export class PostQueryService {
   constructor(
     @InjectRepository(Post)
     private readonly postRepository: Repository<Post>,
+    @InjectRepository(PostLike)
+    private readonly postLikeRepository: Repository<PostLike>,
+    @InjectRepository(Attachment)
+    private readonly s3StorageService: S3StorageService,
   ) {}
 
   /*
    * pagination option을 적용하여 글 목록을 조회한다.
-   * @returns 글 목록, attachment URL, cursor
+   * @returns 해당 글, userId에 대응하는 user와의 관계, attachment들의 url 맵
    */
-  async listPosts({
-    limit,
-    orderBy,
-    orderDirection,
-    category,
-    cursor,
-  }: ListPostsOptions): Promise<ListPostsResult> {
+  async listPosts(
+    userId: number,
+    {
+      limit,
+      orderBy,
+      orderDirection,
+      category,
+      cursor,
+    }: ListPostsPaginationOptions,
+  ): Promise<ListPostsResult> {
     const decodedCursor = cursor && decodeCursor(cursor);
 
     if (
@@ -89,7 +125,10 @@ export class PostQueryService {
     const cursorOp = orderDirection === "asc" ? ">" : "<";
     const orderEntry = orderByMap[orderBy];
 
-    const qb = this.postRepository.createQueryBuilder("post");
+    const qb = this.postRepository
+      .createQueryBuilder("post")
+      .leftJoinAndSelect("post.author", "author")
+      .leftJoinAndSelect("post.attachments", "attachment");
 
     if (category) {
       qb.where("post.category = :category", { category });
@@ -115,9 +154,33 @@ export class PostQueryService {
       .limit(limit)
       .getMany();
 
+    const postIds = posts.map((p) => p.id);
+    const likedPostIds = new Set(
+      postIds.length > 0
+        ? (
+            await this.postLikeRepository.find({
+              where: {
+                user: { id: userId },
+                post: { id: In(postIds) },
+              },
+              relations: { post: true },
+            })
+          ).map((l) => l.post.id)
+        : [],
+    );
+
+    const attachments = posts.flatMap((p) => p.attachments);
+    const attachmentToUrl = this.buildAttachmentToUrl(attachments);
+
     const lastPost = posts.at(-1)!;
     return {
-      posts,
+      entries: posts.map((post) => ({
+        post,
+        withUser: {
+          isOwner: post.author.id === userId,
+          isLiked: likedPostIds.has(post.id),
+        },
+      })),
       nextCursor:
         posts.length === limit
           ? encodeCursor({
@@ -128,18 +191,48 @@ export class PostQueryService {
               cursorValue: orderEntry.getValue(lastPost),
             })
           : undefined,
+      attachmentToUrl,
     };
   }
 
   /**
    * postId에 대응하는 글 하나를 조회한다.
-   * @returns 해당 글, attachment URL
+   * @returns 해당 글, userId에 대응하는 user와의 관계, attachment들의 url 맵
    */
-  async getPost(postId: number): Promise<Post> {
-    const post = await this.postRepository.findOneBy({ id: postId });
+  async getPost(userId: number, postId: number): Promise<GetPostResult> {
+    const post = await this.postRepository.findOne({
+      where: { id: postId },
+      relations: { author: true, attachments: true },
+    });
     if (!post) {
       throw new PostNotFoundError();
     }
-    return post;
+
+    const isLiked = await this.postLikeRepository.existsBy({
+      user: { id: userId },
+      post: { id: postId },
+    });
+
+    const attachmentToUrl = this.buildAttachmentToUrl(post.attachments);
+
+    return {
+      entry: {
+        post,
+        withUser: {
+          isOwner: post.author.id === userId,
+          isLiked,
+        },
+      },
+      attachmentToUrl,
+    };
+  }
+
+  private buildAttachmentToUrl(attachments: Attachment[]): AttachmentToUrlMap {
+    return Object.fromEntries(
+      attachments.map((a) => [
+        a.id,
+        this.s3StorageService.getPublicUrl(a.s3Key),
+      ]),
+    );
   }
 }

--- a/apps/backend/src/post/post.controller.ts
+++ b/apps/backend/src/post/post.controller.ts
@@ -1,0 +1,203 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Put,
+  Post,
+} from "@nestjs/common";
+import {
+  CreatePostRequestDtoSchema,
+  CreatePostResponseDtoSchema,
+  DeletePostResponseDtoSchema,
+  GetPostResponseDtoSchema,
+  idParamSchema,
+  ListPostsQueryDtoSchema,
+  ListPostsResponseDtoSchema,
+  SetPostLikeRequestDtoSchema,
+  SetPostLikeResponseDtoSchema,
+  UpdatePostRequestDtoSchema,
+  UpdatePostResponseDtoSchema,
+} from "@mindseed/api-types";
+import type {
+  CreatePostRequestDto,
+  CreatePostSuccessResponseDto,
+  DeletePostSuccessResponseDto,
+  GetPostSuccessResponseDto,
+  ListPostsQueryDto,
+  ListPostsSuccessResponseDto,
+  SetPostLikeRequestDto,
+  SetPostLikeSuccessResponseDto,
+  UpdatePostRequestDto,
+  UpdatePostSuccessResponseDto,
+} from "@mindseed/api-types";
+import { PostCategory } from "./post.entity";
+import { PostQueryService } from "./post-query.service";
+import { PostMutationService } from "./post-mutation.service";
+import {
+  ZodBody,
+  ZodParam,
+  ZodQuery,
+} from "src/common/pipes/zod-validation.decorator";
+import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
+import { CurrentUser, UserOnly } from "src/auth/decorators/auth.decorators";
+import { User } from "src/user/user.entity";
+
+type ApiCategory = "dummy1" | "dummy2" | "dummy3";
+
+const apiToEntityCategory: Record<ApiCategory, PostCategory> = {
+  dummy1: PostCategory.DUMMY1,
+  dummy2: PostCategory.DUMMY2,
+  dummy3: PostCategory.DUMMY3,
+};
+
+const entityToApiCategory: Record<PostCategory, ApiCategory> = {
+  [PostCategory.DUMMY1]: "dummy1",
+  [PostCategory.DUMMY2]: "dummy2",
+  [PostCategory.DUMMY3]: "dummy3",
+};
+
+@Controller("/posts")
+export class PostController {
+  constructor(
+    private readonly postQueryService: PostQueryService,
+    private readonly postMutationService: PostMutationService,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UserOnly()
+  @ZodEncodeResponse(CreatePostResponseDtoSchema)
+  async createPost(
+    @CurrentUser() user: User,
+    @ZodBody(CreatePostRequestDtoSchema) body: CreatePostRequestDto,
+  ): Promise<CreatePostSuccessResponseDto> {
+    const post = await this.postMutationService.createPost({
+      userId: user.id,
+      content: body.content,
+      category: apiToEntityCategory[body.category],
+      nickname: body.nickname,
+      attachmentIds: body.attachmentIds,
+    });
+    return { success: true, data: { id: post.id } };
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(ListPostsResponseDtoSchema)
+  async listPosts(
+    @CurrentUser() user: User,
+    @ZodQuery(ListPostsQueryDtoSchema) query: ListPostsQueryDto,
+  ): Promise<ListPostsSuccessResponseDto> {
+    const { entries, nextCursor, attachmentToUrl } =
+      await this.postQueryService.listPosts(user.id, {
+        cursor: query.cursor,
+        limit: query.limit,
+        category: query.category
+          ? apiToEntityCategory[query.category]
+          : undefined,
+        orderBy: query.orderBy,
+        orderDirection: query.orderDirection,
+      });
+
+    return {
+      success: true,
+      data: {
+        posts: entries.map(({ post, withUser }) => ({
+          id: post.id,
+          content: post.content,
+          category: entityToApiCategory[post.category],
+          author: { nickname: post.nickname },
+          attachments: post.attachments.map((a) => ({
+            id: a.id,
+            url: attachmentToUrl[a.id],
+          })),
+          likeCount: post.likeCount,
+          isOwner: withUser.isOwner,
+          isLiked: withUser.isLiked,
+          createdAt: post.createdAt,
+          updatedAt: post.updatedAt,
+        })),
+        nextCursor: nextCursor ?? null,
+      },
+    };
+  }
+
+  @Get(":id")
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(GetPostResponseDtoSchema)
+  async getPost(
+    @CurrentUser() user: User,
+    @ZodParam("id", idParamSchema) id: number,
+  ): Promise<GetPostSuccessResponseDto> {
+    const { entry, attachmentToUrl } = await this.postQueryService.getPost(
+      user.id,
+      id,
+    );
+    return {
+      success: true,
+      data: {
+        id: entry.post.id,
+        content: entry.post.content,
+        category: entityToApiCategory[entry.post.category],
+        author: { nickname: entry.post.nickname },
+        attachments: entry.post.attachments.map((a) => ({
+          id: a.id,
+          url: attachmentToUrl[a.id],
+        })),
+        likeCount: entry.post.likeCount,
+        isOwner: entry.withUser.isOwner,
+        isLiked: entry.withUser.isLiked,
+        createdAt: entry.post.createdAt,
+        updatedAt: entry.post.updatedAt,
+      },
+    };
+  }
+
+  @Put(":id")
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(UpdatePostResponseDtoSchema)
+  async updatePost(
+    @CurrentUser() user: User,
+    @ZodParam("id", idParamSchema) id: number,
+    @ZodBody(UpdatePostRequestDtoSchema) body: UpdatePostRequestDto,
+  ): Promise<UpdatePostSuccessResponseDto> {
+    await this.postMutationService.updatePost({
+      userId: user.id,
+      postId: id,
+      content: body.content,
+      category: apiToEntityCategory[body.category],
+      attachmentIds: body.attachmentIds,
+    });
+    return { success: true, data: null };
+  }
+
+  @Put(":id/like")
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(SetPostLikeResponseDtoSchema)
+  async setPostLike(
+    @CurrentUser() user: User,
+    @ZodParam("id", idParamSchema) id: number,
+    @ZodBody(SetPostLikeRequestDtoSchema) body: SetPostLikeRequestDto,
+  ): Promise<SetPostLikeSuccessResponseDto> {
+    await this.postMutationService.setPostLike(user.id, id, body.liked);
+    return { success: true, data: null };
+  }
+
+  @Delete(":id")
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(DeletePostResponseDtoSchema)
+  async deletePost(
+    @CurrentUser() user: User,
+    @ZodParam("id", idParamSchema) id: number,
+  ): Promise<DeletePostSuccessResponseDto> {
+    await this.postMutationService.deletePost(user.id, id);
+    return { success: true, data: null };
+  }
+}

--- a/apps/backend/src/post/post.entity.ts
+++ b/apps/backend/src/post/post.entity.ts
@@ -43,4 +43,7 @@ export class Post {
 
   @OneToMany(() => Attachment, (attachment) => attachment.post)
   attachments: Attachment[];
+
+  @Column({ name: "like_count", default: 0 })
+  likeCount: number;
 }

--- a/apps/backend/src/post/post.module.ts
+++ b/apps/backend/src/post/post.module.ts
@@ -4,6 +4,7 @@ import { Post } from "./post.entity";
 import { PostLike } from "./post-like.entity";
 import { Attachment } from "../attachment/attachment.entity";
 import { PostService } from "./post.service";
+import { PostController } from "./post.controller";
 import { S3StorageModule } from "src/s3-storage/s3-storage.module";
 import { AuthModule } from "src/auth/auth.module";
 import { UserModule } from "src/user/user.module";
@@ -15,6 +16,7 @@ import { UserModule } from "src/user/user.module";
     AuthModule,
     UserModule,
   ],
+  controllers: [PostController],
   providers: [PostService],
 })
 export class PostModule {}

--- a/apps/backend/src/post/post.module.ts
+++ b/apps/backend/src/post/post.module.ts
@@ -3,7 +3,8 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { Post } from "./post.entity";
 import { PostLike } from "./post-like.entity";
 import { Attachment } from "../attachment/attachment.entity";
-import { PostService } from "./post.service";
+import { PostQueryService } from "./post-query.service";
+import { PostMutationService } from "./post-mutation.service";
 import { PostController } from "./post.controller";
 import { S3StorageModule } from "src/s3-storage/s3-storage.module";
 import { AuthModule } from "src/auth/auth.module";
@@ -17,6 +18,6 @@ import { UserModule } from "src/user/user.module";
     UserModule,
   ],
   controllers: [PostController],
-  providers: [PostService],
+  providers: [PostQueryService, PostMutationService],
 })
 export class PostModule {}

--- a/apps/backend/src/post/post.service.spec.ts
+++ b/apps/backend/src/post/post.service.spec.ts
@@ -112,7 +112,7 @@ describe("PostService", () => {
         },
         {
           provide: getDataSourceToken(),
-          useValue: dataSource
+          useValue: dataSource,
         },
         { provide: S3_CLIENT, useValue: mockS3Client },
         { provide: s3Config.KEY, useValue: mockS3Config },
@@ -520,17 +520,24 @@ describe("PostService", () => {
       // When: liked를 true로 지정하여 요청
       await postService.setPostLike(user.id, post.id, true);
 
-      // Then: post like entity 생성
-      const like = await postLikeRepository.findOne({
-        where: { post: { id: post.id }, user: { id: user.id } },
+      // Then: post like entity 생성, likeCount 업데이트
+      const like = await postLikeRepository.findOneBy({
+        post: { id: post.id },
+        user: { id: user.id },
       });
       expect(like).not.toBeNull();
+      const updatedPost = await postRepository.findOneBy({
+        id: post.id,
+      });
+      expect(updatedPost!.likeCount).toBe(1);
     });
 
     it("success: liked true -> true, post like entity 유지", async () => {
       // Given: 글이 존재하는 경우, liked: true
       const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const post = await saveTestPost(postRepository, user.id, {
+        likeCount: 1,
+      });
       await postLikeRepository.save(
         postLikeRepository.create({
           user: { id: user.id },
@@ -541,17 +548,21 @@ describe("PostService", () => {
       // When: liked를 true로 지정하여 요청
       await postService.setPostLike(user.id, post.id, true);
 
-      // Then: post like entity 유지
+      // Then: post like entity 유지, likeCount 유지
       const like = await postLikeRepository.findOne({
         where: { post: { id: post.id }, user: { id: user.id } },
       });
       expect(like).not.toBeNull();
+      const updatedPost = await postRepository.findOneBy({ id: post.id });
+      expect(updatedPost!.likeCount).toBe(1);
     });
 
     it("success: liked true -> false, post like entity 삭제", async () => {
       // Given: 글이 존재하는 경우, liked: true
       const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const post = await saveTestPost(postRepository, user.id, {
+        likeCount: 1,
+      });
       await postLikeRepository.save(
         postLikeRepository.create({
           user: { id: user.id },
@@ -562,11 +573,13 @@ describe("PostService", () => {
       // When: liked를 false로 지정하여 요청
       await postService.setPostLike(user.id, post.id, false);
 
-      // Then: post like entity 삭제
+      // Then: post like entity 삭제, likeCount 업데이트
       const like = await postLikeRepository.findOne({
         where: { post: { id: post.id }, user: { id: user.id } },
       });
       expect(like).toBeNull();
+      const updatedPost = await postRepository.findOneBy({ id: post.id });
+      expect(updatedPost!.likeCount).toBe(0);
     });
 
     it("success: liked false -> false, post like entity 없음 유지", async () => {
@@ -577,11 +590,13 @@ describe("PostService", () => {
       // When: liked를 false로 지정하여 요청
       await postService.setPostLike(user.id, post.id, false);
 
-      // Then: post like entity 삭제
+      // Then: post like entity 없음 유지, likeCount 유지
       const like = await postLikeRepository.findOne({
         where: { post: { id: post.id }, user: { id: user.id } },
       });
       expect(like).toBeNull();
+      const updatedPost = await postRepository.findOneBy({ id: post.id });
+      expect(updatedPost!.likeCount).toBe(0);
     });
 
     it("존재하지 않는 글 처리", async () => {

--- a/apps/backend/src/post/post.service.spec.ts
+++ b/apps/backend/src/post/post.service.spec.ts
@@ -16,19 +16,11 @@ import { PostLike } from "./post-like.entity";
 import { Attachment } from "../attachment/attachment.entity";
 import { User, UserRole } from "../user/user.entity";
 import { UserProfile } from "../user/user-profile.entity";
-import { S3_CLIENT } from "src/s3-storage/s3-storage.module";
-import { s3Config } from "src/config";
+import { S3StorageService } from "src/s3-storage/s3-storage.service";
+import { FakeS3StorageService } from "src/s3-storage/s3-storage.service.fake";
 import { initializePgMem } from "src/test/pg-mem.helper";
-import { DeleteObjectsCommand } from "@aws-sdk/client-s3";
 
 const entities = [UserProfile, User, Post, PostLike, Attachment];
-
-const mockS3Config = {
-  region: "us-east-1",
-  accessKeyId: "test-key",
-  secretAccessKey: "test-secret",
-  bucket: "test-bucket",
-};
 
 let userCounter = 0;
 
@@ -84,7 +76,7 @@ describe("PostService", () => {
   let postLikeRepository: Repository<PostLike>;
   let attachmentRepository: Repository<Attachment>;
   let userRepository: Repository<User>;
-  let mockS3Client: { send: jest.Mock };
+  let fakeS3: FakeS3StorageService;
   let dataSource: DataSource;
   let dbBackup: PGMem.IBackup;
 
@@ -93,7 +85,7 @@ describe("PostService", () => {
     dataSource = ds;
     dbBackup = backup;
 
-    mockS3Client = { send: jest.fn() };
+    fakeS3 = new FakeS3StorageService();
 
     module = await Test.createTestingModule({
       providers: [
@@ -114,8 +106,7 @@ describe("PostService", () => {
           provide: getDataSourceToken(),
           useValue: dataSource,
         },
-        { provide: S3_CLIENT, useValue: mockS3Client },
-        { provide: s3Config.KEY, useValue: mockS3Config },
+        { provide: S3StorageService, useValue: fakeS3 },
       ],
     }).compile();
 
@@ -128,7 +119,7 @@ describe("PostService", () => {
 
   beforeEach(() => {
     dbBackup.restore();
-    mockS3Client.send.mockReset();
+    fakeS3.reset();
     jest.restoreAllMocks();
   });
 
@@ -372,11 +363,10 @@ describe("PostService", () => {
       const oldAttachment = await saveTestAttachment(attachmentRepository, {
         post,
       });
+      fakeS3.put(oldAttachment.s3Key);
 
       // Given: new attachments가 confirmed이며 associated 되지 않은 경우
       const newAttachment = await saveTestAttachment(attachmentRepository);
-      // assumption: send() 호출 시 해당 반환값은 사용되지 않음
-      mockS3Client.send.mockResolvedValue({});
 
       // When: 글 업데이트 시도
       await postService.updatePost({
@@ -387,7 +377,7 @@ describe("PostService", () => {
         attachmentIds: [newAttachment.id],
       });
 
-      // Then: 글 및 new attachments 업데이트됨, old attachments 삭제
+      // Then: 글 및 new attachments 업데이트됨
       const updatedPost = await postRepository.findOne({
         where: { id: post.id },
         relations: ["attachments"],
@@ -399,12 +389,12 @@ describe("PostService", () => {
       expect(updatedPost!.attachments.map((a) => a.id)).toEqual(
         expect.arrayContaining([newAttachment.id]),
       );
+
+      // Then: old attachments 삭제
       expect(
         await attachmentRepository.findOneBy({ id: oldAttachment.id }),
       ).toBeNull();
-      expect(mockS3Client.send).toHaveBeenCalledWith(
-        expect.any(DeleteObjectsCommand),
-      );
+      expect(await fakeS3.exists(oldAttachment.s3Key)).toBe(false);
     });
 
     it("존재하지 않는 글 처리", async () => {
@@ -619,7 +609,7 @@ describe("PostService", () => {
       const attachment = await saveTestAttachment(attachmentRepository, {
         post,
       });
-      mockS3Client.send.mockResolvedValue({});
+      fakeS3.put(attachment.s3Key);
 
       // When: 글 삭제 시도
       await postService.deletePost(user.id, post.id);
@@ -629,9 +619,7 @@ describe("PostService", () => {
       expect(
         await attachmentRepository.findOneBy({ id: attachment.id }),
       ).toBeNull();
-      expect(mockS3Client.send).toHaveBeenCalledWith(
-        expect.any(DeleteObjectsCommand),
-      );
+      expect(await fakeS3.exists(attachment.s3Key)).toBe(false);
     });
 
     it("존재하지 않는 글 처리", async () => {

--- a/apps/backend/src/post/post.service.ts
+++ b/apps/backend/src/post/post.service.ts
@@ -101,6 +101,10 @@ export class PostService {
     private readonly s3cfg: ConfigType<typeof s3Config>,
   ) {}
 
+  /*
+   * options를 기반으로 새 글을 생성한다.
+   * @returns 생성된 글
+   */
   async createPost({
     userId,
     content,
@@ -123,6 +127,10 @@ export class PostService {
     return post;
   }
 
+  /*
+   * pagination option을 적용하여 글 목록을 조회한다.
+   * @returns 글 목록, attachment URL, cursor
+   */
   async listPosts({
     limit,
     orderBy,
@@ -187,6 +195,10 @@ export class PostService {
     };
   }
 
+  /**
+   * postId에 대응하는 글 하나를 조회한다.
+   * @returns 해당 글, attachment URL
+   */
   async getPost(postId: number): Promise<Post> {
     const post = await this.postRepository.findOneBy({ id: postId });
     if (!post) {
@@ -195,6 +207,9 @@ export class PostService {
     return post;
   }
 
+  /**
+   * userId에 대응하는 사용자가 글의 작성자인 경우 글을 업데이트한다.
+   */
   async updatePost({
     userId,
     postId,
@@ -244,45 +259,58 @@ export class PostService {
     await this.deleteAttachmentsInS3(post.attachments);
   }
 
+  /**
+   * userId에 대한 사용자의 글 좋아요 표시 유무를 업데이트한다.
+   */
   async setPostLike(
     userId: number,
     postId: number,
     liked: boolean,
   ): Promise<void> {
-    const postExists = await this.postRepository.existsBy({
+    const existingPost = await this.postRepository.findOneBy({
       id: postId,
     });
 
-    if (!postExists) {
+    if (!existingPost) {
       throw new PostNotFoundError();
     }
 
-    if (liked) {
-      const postLikeExists = await this.postLikeRepository.existsBy({
-        user: { id: userId },
-        post: { id: postId },
-      });
+    const postLikeExists = await this.postLikeRepository.existsBy({
+      user: { id: userId },
+      post: { id: postId },
+    });
 
-      if (postLikeExists) {
-        return;
+    await this.dataSource.transaction(async (manager) => {
+      const postLikeRepository = manager.getRepository(PostLike);
+      const postRepository = manager.getRepository(Post);
+
+      if (liked && !postLikeExists) {
+        existingPost.likeCount++;
+        await postRepository.save(existingPost);
+
+        await postLikeRepository.save(
+          this.postLikeRepository.create({
+            user: { id: userId },
+            post: { id: postId },
+          }),
+        );
       }
 
-      await this.postLikeRepository.save(
-        this.postLikeRepository.create({
+      if (!liked && postLikeExists) {
+        existingPost.likeCount--;
+        await postRepository.save(existingPost);
+
+        await postLikeRepository.delete({
           user: { id: userId },
           post: { id: postId },
-        }),
-      );
-    } else {
-      // delete()는 existence check를 하지 않기 때문에, 원래 liked 하지 않은
-      // 상태였어도 정상 작동합니다.
-      this.postLikeRepository.delete({
-        user: { id: userId },
-        post: { id: postId },
-      });
-    }
+        });
+      }
+    });
   }
 
+  /**
+   * userId에 대응하는 사용자가 글의 작성자인 경우, 글을 삭제한다.2
+   */
   async deletePost(userId: number, postId: number): Promise<void> {
     const post = await this.postRepository.findOne({
       where: { id: postId },
@@ -305,9 +333,9 @@ export class PostService {
   }
 
   /**
-   * attachmentIds가 가리키는 attachment가 모두 post와 연관될 수 있는지를
+   * attachmentIds가 가리키는 attachment가 모두 글과 연관될 수 있는지를
    * 확인한다.
-   * 존재하지 않는 경우 / confirmed 되지 않은 경우 / 이미 다른 post와 연관되어 있으면
+   * 존재하지 않는 경우 / confirmed 되지 않은 경우 / 이미 다른 글과 연관되어 있으면
    * throw 한다.
    */
   private async ensureAttachmentValidityForPostAssociation(
@@ -332,6 +360,9 @@ export class PostService {
     }
   }
 
+  /**
+   * attachments를 S3 상에서 삭제한다.
+   */
   private async deleteAttachmentsInS3(attachments: Attachment[]) {
     await this.s3Client.send(
       new DeleteObjectsCommand({

--- a/apps/backend/src/post/post.service.ts
+++ b/apps/backend/src/post/post.service.ts
@@ -1,13 +1,10 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { InjectDataSource, InjectRepository } from "@nestjs/typeorm";
 import { DataSource, In, IsNull, Repository } from "typeorm";
-import type { ConfigType } from "@nestjs/config";
-import { DeleteObjectsCommand, S3Client } from "@aws-sdk/client-s3";
 import { Post, PostCategory } from "./post.entity";
 import { PostLike } from "./post-like.entity";
 import { Attachment } from "../attachment/attachment.entity";
-import { S3_CLIENT } from "src/s3-storage/s3-storage.module";
-import { s3Config } from "src/config";
+import { S3StorageService } from "src/s3-storage/s3-storage.service";
 import {
   AttachmentAlreadyAssociatedError,
   AttachmentNotFoundError,
@@ -95,9 +92,7 @@ export class PostService {
     private readonly attachmentRepository: Repository<Attachment>,
     @InjectDataSource()
     private readonly dataSource: DataSource,
-    @Inject(S3_CLIENT) private readonly s3Client: S3Client,
-    @Inject(s3Config.KEY)
-    private readonly s3cfg: ConfigType<typeof s3Config>,
+    private readonly s3StorageService: S3StorageService,
   ) {}
 
   /*
@@ -255,7 +250,9 @@ export class PostService {
       });
     });
 
-    await this.deleteAttachmentsInS3(post.attachments);
+    await this.s3StorageService.deleteMany(
+      post.attachments.map((a) => a.s3Key),
+    );
   }
 
   /**
@@ -328,7 +325,9 @@ export class PostService {
       id: postId,
     });
 
-    await this.deleteAttachmentsInS3(post.attachments);
+    await this.s3StorageService.deleteMany(
+      post.attachments.map((a) => a.s3Key),
+    );
   }
 
   /**
@@ -357,21 +356,5 @@ export class PostService {
     if (validAttachmentsCount < attachmentIds.length) {
       throw new AttachmentAlreadyAssociatedError();
     }
-  }
-
-  /**
-   * attachments를 S3 상에서 삭제한다.
-   */
-  private async deleteAttachmentsInS3(attachments: Attachment[]) {
-    await this.s3Client.send(
-      new DeleteObjectsCommand({
-        Bucket: this.s3cfg.bucket,
-        Delete: {
-          Objects: attachments.map((attachment) => ({
-            Key: attachment.s3Key,
-          })),
-        },
-      }),
-    );
   }
 }

--- a/apps/backend/src/post/post.service.ts
+++ b/apps/backend/src/post/post.service.ts
@@ -15,7 +15,6 @@ import {
   NotPostAuthorError,
   PostNotFoundError,
 } from "./post.errors";
-import { createAttachmentS3Key } from "src/attachment/attachment-s3-key.helper";
 
 export type CreatePostOptions = {
   userId: number;
@@ -369,7 +368,7 @@ export class PostService {
         Bucket: this.s3cfg.bucket,
         Delete: {
           Objects: attachments.map((attachment) => ({
-            Key: createAttachmentS3Key(attachment.s3Key),
+            Key: attachment.s3Key,
           })),
         },
       }),

--- a/apps/backend/src/s3-storage/s3-client-storage.service.ts
+++ b/apps/backend/src/s3-storage/s3-client-storage.service.ts
@@ -32,6 +32,10 @@ export class S3ClientStorageService extends S3StorageService {
     );
   }
 
+  getPublicUrl(key: string): string {
+    return `https://${this.s3cfg.endpoint}/${this.s3cfg.bucket}/${key}`;
+  }
+
   async exists(key: string): Promise<boolean> {
     try {
       await this.s3Client.send(

--- a/apps/backend/src/s3-storage/s3-client-storage.service.ts
+++ b/apps/backend/src/s3-storage/s3-client-storage.service.ts
@@ -8,7 +8,7 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { S3_CLIENT } from "./s3-storage.module";
+import { S3_CLIENT } from "./s3-client.di-token";
 import { s3Config } from "src/config";
 import { S3StorageService } from "./s3-storage.service";
 

--- a/apps/backend/src/s3-storage/s3-client-storage.service.ts
+++ b/apps/backend/src/s3-storage/s3-client-storage.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, Inject } from "@nestjs/common";
+import type { ConfigType } from "@nestjs/config";
+import {
+  DeleteObjectsCommand,
+  HeadObjectCommand,
+  NotFound,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { S3_CLIENT } from "./s3-storage.module";
+import { s3Config } from "src/config";
+import { S3StorageService } from "./s3-storage.service";
+
+// 2026-03-26 testability를 위해 wrapper class 작성
+
+@Injectable()
+export class S3ClientStorageService extends S3StorageService {
+  constructor(
+    @Inject(S3_CLIENT) private readonly s3Client: S3Client,
+    @Inject(s3Config.KEY)
+    private readonly s3cfg: ConfigType<typeof s3Config>,
+  ) {
+    super();
+  }
+
+  async getUploadUrl(key: string, expiresIn: number): Promise<string> {
+    return getSignedUrl(
+      this.s3Client,
+      new PutObjectCommand({ Bucket: this.s3cfg.bucket!, Key: key }),
+      { expiresIn },
+    );
+  }
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      await this.s3Client.send(
+        new HeadObjectCommand({ Bucket: this.s3cfg.bucket!, Key: key }),
+      );
+      return true;
+    } catch (error) {
+      if (error instanceof NotFound) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async deleteMany(keys: string[]): Promise<void> {
+    if (keys.length === 0) {
+      return;
+    }
+
+    await this.s3Client.send(
+      new DeleteObjectsCommand({
+        Bucket: this.s3cfg.bucket,
+        Delete: {
+          Objects: keys.map((key) => ({ Key: key })),
+        },
+      }),
+    );
+  }
+}

--- a/apps/backend/src/s3-storage/s3-client.di-token.ts
+++ b/apps/backend/src/s3-storage/s3-client.di-token.ts
@@ -1,0 +1,1 @@
+export const S3_CLIENT = Symbol("S3_CLIENT");

--- a/apps/backend/src/s3-storage/s3-storage.module.ts
+++ b/apps/backend/src/s3-storage/s3-storage.module.ts
@@ -2,11 +2,14 @@ import { Module } from "@nestjs/common";
 import { ConfigType } from "@nestjs/config";
 import { S3Client } from "@aws-sdk/client-s3";
 import { s3Config } from "src/config";
+import { S3StorageService } from "./s3-storage.service";
+import { S3ClientStorageService } from "./s3-client-storage.service";
 
 export const S3_CLIENT = Symbol("S3_CLIENT");
 
 @Module({
   providers: [
+    { provide: S3StorageService, useClass: S3ClientStorageService },
     {
       provide: S3_CLIENT,
       inject: [s3Config.KEY],
@@ -21,6 +24,6 @@ export const S3_CLIENT = Symbol("S3_CLIENT");
         }),
     },
   ],
-  exports: [S3_CLIENT],
+  exports: [S3StorageService],
 })
 export class S3StorageModule {}

--- a/apps/backend/src/s3-storage/s3-storage.module.ts
+++ b/apps/backend/src/s3-storage/s3-storage.module.ts
@@ -4,8 +4,7 @@ import { S3Client } from "@aws-sdk/client-s3";
 import { s3Config } from "src/config";
 import { S3StorageService } from "./s3-storage.service";
 import { S3ClientStorageService } from "./s3-client-storage.service";
-
-export const S3_CLIENT = Symbol("S3_CLIENT");
+import { S3_CLIENT } from "./s3-client.di-token";
 
 @Module({
   providers: [

--- a/apps/backend/src/s3-storage/s3-storage.service.fake.ts
+++ b/apps/backend/src/s3-storage/s3-storage.service.fake.ts
@@ -1,0 +1,45 @@
+import { S3StorageService } from "./s3-storage.service";
+
+export class FakeS3StorageService extends S3StorageService {
+  shouldFailOnPresigning = false;
+
+  private readonly keysWithPresignedUrl = new Set<string>();
+  private readonly objects = new Set<string>();
+
+  // eslint-disable-next-line
+  async getUploadUrl(key: string, _expiresIn: number): Promise<string> {
+    if (this.shouldFailOnPresigning) {
+      throw new Error("S3 failure");
+    }
+    this.keysWithPresignedUrl.add(key);
+    return this.getPresignedUrlForKey(key);
+  }
+
+  async exists(key: string): Promise<boolean> {
+    return this.objects.has(key);
+  }
+
+  async deleteMany(keys: string[]): Promise<void> {
+    keys.forEach((key) => this.objects.delete(key));
+  }
+
+  /* test methods */
+
+  reset(): void {
+    this.objects.clear();
+    this.keysWithPresignedUrl.clear();
+    this.shouldFailOnPresigning = false;
+  }
+
+  put(key: string): void {
+    this.objects.add(key);
+  }
+
+  isPresignedUrlValid(key: string, url: string): boolean {
+    return this.getPresignedUrlForKey(key) === url;
+  }
+
+  private getPresignedUrlForKey(key: string): string {
+    return `https://fake-s3/${key}`;
+  }
+}

--- a/apps/backend/src/s3-storage/s3-storage.service.fake.ts
+++ b/apps/backend/src/s3-storage/s3-storage.service.fake.ts
@@ -15,6 +15,10 @@ export class FakeS3StorageService extends S3StorageService {
     return this.getPresignedUrlForKey(key);
   }
 
+  getPublicUrl(key: string): string {
+    return `https://fake-s3/${key}`;
+  }
+
   async exists(key: string): Promise<boolean> {
     return this.objects.has(key);
   }
@@ -40,6 +44,6 @@ export class FakeS3StorageService extends S3StorageService {
   }
 
   private getPresignedUrlForKey(key: string): string {
-    return `https://fake-s3/${key}`;
+    return `https://fake-s3-presigned/${key}`;
   }
 }

--- a/apps/backend/src/s3-storage/s3-storage.service.ts
+++ b/apps/backend/src/s3-storage/s3-storage.service.ts
@@ -6,6 +6,7 @@ import { Injectable } from "@nestjs/common";
 @Injectable()
 export abstract class S3StorageService {
   abstract getUploadUrl(key: string, expiresIn: number): Promise<string>;
+  abstract getPublicUrl(key: string): string;
   abstract exists(key: string): Promise<boolean>;
   abstract deleteMany(keys: string[]): Promise<void>;
 }

--- a/apps/backend/src/s3-storage/s3-storage.service.ts
+++ b/apps/backend/src/s3-storage/s3-storage.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from "@nestjs/common";
+
+/**
+ * S3 storage에 대한 wrapper class
+ */
+@Injectable()
+export abstract class S3StorageService {
+  abstract getUploadUrl(key: string, expiresIn: number): Promise<string>;
+  abstract exists(key: string): Promise<boolean>;
+  abstract deleteMany(keys: string[]): Promise<void>;
+}

--- a/packages/api-types/src/common/codecs.ts
+++ b/packages/api-types/src/common/codecs.ts
@@ -1,0 +1,15 @@
+import z from "zod";
+
+export const dateSerializerCodec = z.codec(z.iso.datetime(), z.date(), {
+  decode: (str) => new Date(str),
+  encode: (date) => date.toISOString(),
+});
+
+export const numberSerializerCodec = z.codec(
+  z.string().regex(z.regexes.number),
+  z.number(),
+  {
+    decode: (str) => Number.parseFloat(str),
+    encode: (num) => num.toString(),
+  },
+);

--- a/packages/api-types/src/common/date-time-codec.ts
+++ b/packages/api-types/src/common/date-time-codec.ts
@@ -1,6 +1,0 @@
-import z from "zod";
-
-export const dateTimeCodec = z.codec(z.iso.datetime(), z.date(), {
-  decode: (str) => new Date(str),
-  encode: (date) => date.toISOString(),
-});

--- a/packages/api-types/src/common/id-param.ts
+++ b/packages/api-types/src/common/id-param.ts
@@ -1,0 +1,6 @@
+import { numberSerializerCodec } from "./codecs";
+
+/*
+ * :id URL parameter validation을 위한 shared schema
+ */
+export const idParamSchema = numberSerializerCodec;

--- a/packages/api-types/src/common/user-dto.ts
+++ b/packages/api-types/src/common/user-dto.ts
@@ -1,12 +1,12 @@
 import z from "zod";
-import { dateTimeCodec } from "./date-time-codec";
+import { dateSerializerCodec } from "./codecs";
 import { UserProfileDtoSchema } from "./user-profile-dto";
 
 export const UserDtoSchema = z.object({
   id: z.int(),
   email: z.email(),
   role: z.enum(["USER", "ADMIN"]),
-  createdAt: dateTimeCodec,
+  createdAt: dateSerializerCodec,
   profile: z.nullable(UserProfileDtoSchema),
 });
 

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -1,5 +1,9 @@
 export * from "./helpers";
 
+export * from "./common/id-param";
+export * from "./common/user-dto";
+export * from "./common/user-profile-dto";
+
 export * from "./auth/common";
 export * from "./auth/complete-signup";
 export * from "./auth/login";

--- a/packages/api-types/src/posts/common.ts
+++ b/packages/api-types/src/posts/common.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { dateTimeCodec } from "../common/date-time-codec";
+import { dateSerializerCodec } from "../common/codecs";
 
 export const PostContentSchema = z.string().min(1).max(200);
 
@@ -29,8 +29,8 @@ export const PostDtoSchema = z.object({
   likeCount: z.int(),
   isOwner: z.boolean(),
   isLiked: z.boolean(),
-  createdAt: dateTimeCodec,
-  updatedAt: dateTimeCodec,
+  createdAt: dateSerializerCodec,
+  updatedAt: dateSerializerCodec,
 });
 
 export type PostDto = z.output<typeof PostDtoSchema>;

--- a/packages/api-types/src/posts/list-posts.ts
+++ b/packages/api-types/src/posts/list-posts.ts
@@ -6,10 +6,11 @@
 import z from "zod";
 import { responseDtoSchema } from "../helpers";
 import { PostCategorySchema, PostDtoSchema } from "./common";
+import { numberSerializerCodec } from "src/common/codecs";
 
 export const ListPostsQueryDtoSchema = z.object({
   cursor: z.string().optional(),
-  limit: z.int().min(1).default(10),
+  limit: numberSerializerCodec.pipe(z.int().min(1)).default(10),
   category: PostCategorySchema.optional(),
   orderBy: z.enum(["createdAt"]).default("createdAt"),
   orderDirection: z.enum(["asc", "desc"]).default("asc"),
@@ -22,7 +23,7 @@ export const ListPostsResponseDtoSchema = responseDtoSchema(
     posts: z.array(PostDtoSchema),
     nextCursor: z.string().nullable(),
   }),
-  z.enum(["INVALID_CURSOR"])
+  z.enum(["INVALID_CURSOR"]),
 );
 
 export type ListPostsResponseDto = z.output<typeof ListPostsResponseDtoSchema>;

--- a/packages/api-types/src/posts/list-posts.ts
+++ b/packages/api-types/src/posts/list-posts.ts
@@ -20,7 +20,7 @@ export type ListPostsQueryDto = z.output<typeof ListPostsQueryDtoSchema>;
 export const ListPostsResponseDtoSchema = responseDtoSchema(
   z.object({
     posts: z.array(PostDtoSchema),
-    nextCursor: z.int().nullable(),
+    nextCursor: z.string().nullable(),
   }),
   z.enum(["INVALID_CURSOR"])
 );

--- a/packages/api-types/tsconfig.json
+++ b/packages/api-types/tsconfig.json
@@ -7,7 +7,8 @@
     "verbatimModuleSyntax": true,
     "declaration": true,
     "declarationMap": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": "./"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## 요약

- Closes #43 
- `PostController`를 구현하고, 이를 위해 `PostService`에 기능 추가 및 리팩토링을 하였습니다.

## 설명

### `backend`

`PostService`에 controller에 필요한 기능들을 추가하였습니다.

- attachment 별 URL 맵
- 좋아요 수
- 글과 사용자 간의 관계 (글 작성자인지, 글에 좋아요를 표시했는지)

또한 이를 위해 다음과 같은 리팩토링을 진행하였습니다.

- S3 storage logic을 `S3StorageService` wrapper class로 분리
- readability를 위해 `PostService`를 `PostQueryService`와 `PostMutationService`로 분리

### `api-types`

- :id URL parameter를 검증하기 위한 shared schema를 추가하였습니다.
- GET /posts의 search parameter들이 올바르도록 수정하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full post endpoints: create, update, list, retrieve, delete, and like/unlike posts with visible like counts.
  * Attachment flow: presigned upload URLs and public attachment URLs for uploaded files.
  * Cursor-based listing with string cursors, category filtering, and ownership/like flags per result.
  * Improved request validation schemas and serialized date/number handling.

* **Bug Fixes / Enhancements**
  * More reliable storage interactions and upload confirmation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->