### PR TITLE
Backend comment controller

### DIFF
--- a/apps/backend/src/comment/comment.controller.ts
+++ b/apps/backend/src/comment/comment.controller.ts
@@ -1,0 +1,83 @@
+import {
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Patch,
+  Post,
+} from "@nestjs/common";
+import type {
+  CreateCommentRequestDto,
+  CreateCommentSuccessResponseDto,
+  DeleteCommentSuccessResponseDto,
+  UpdateCommentRequestDto,
+  UpdateCommentSuccessResponseDto,
+} from "@mindseed/api-types";
+import {
+  CreateCommentRequestDtoSchema,
+  CreateCommentResponseDtoSchema,
+  DeleteCommentResponseDtoSchema,
+  UpdateCommentRequestDtoSchema,
+  UpdateCommentResponseDtoSchema,
+  idParamSchema,
+} from "@mindseed/api-types";
+import { CommentService } from "./comment.service";
+import { ZodBody, ZodParam } from "src/common/pipes/zod-validation.decorator";
+import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
+import { CurrentUser, UserOnly } from "src/auth/decorators/auth.decorators";
+import { User } from "src/user/entities/user.entity";
+
+@Controller("/posts/:postId/comments")
+export class CommentController {
+  constructor(private readonly commentService: CommentService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UserOnly()
+  @ZodEncodeResponse(CreateCommentResponseDtoSchema)
+  async createComment(
+    @CurrentUser() user: User,
+    @ZodParam("postId", idParamSchema) postId: number,
+    @ZodBody(CreateCommentRequestDtoSchema) body: CreateCommentRequestDto,
+  ): Promise<CreateCommentSuccessResponseDto> {
+    const comment = await this.commentService.createComment({
+      postId,
+      userId: user.id,
+      nickname: body.nickname,
+      content: body.content,
+    });
+    return { success: true, data: { id: comment.id } };
+  }
+
+  @Patch(":commentId")
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(UpdateCommentResponseDtoSchema)
+  async updateComment(
+    @CurrentUser() user: User,
+    @ZodParam("postId", idParamSchema) postId: number,
+    @ZodParam("commentId", idParamSchema) commentId: number,
+    @ZodBody(UpdateCommentRequestDtoSchema) body: UpdateCommentRequestDto,
+  ): Promise<UpdateCommentSuccessResponseDto> {
+    await this.commentService.updateComment({
+      postId,
+      commentId,
+      userId: user.id,
+      content: body.content,
+    });
+    return { success: true, data: null };
+  }
+
+  @Delete(":commentId")
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(DeleteCommentResponseDtoSchema)
+  async deleteComment(
+    @CurrentUser() user: User,
+    @ZodParam("postId", idParamSchema) postId: number,
+    @ZodParam("commentId", idParamSchema) commentId: number,
+  ): Promise<DeleteCommentSuccessResponseDto> {
+    await this.commentService.deleteComment(postId, commentId, user.id);
+    return { success: true, data: null };
+  }
+}

--- a/apps/backend/src/comment/comment.module.ts
+++ b/apps/backend/src/comment/comment.module.ts
@@ -3,9 +3,17 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { PostComment } from "./entities/post-comment.entity";
 import { Post } from "src/post/entities/post.entity";
 import { CommentService } from "./comment.service";
+import { CommentController } from "./comment.controller";
+import { AuthModule } from "src/auth/auth.module";
+import { UserModule } from "src/user/user.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PostComment, Post])],
+  imports: [
+    TypeOrmModule.forFeature([PostComment, Post]),
+    AuthModule,
+    UserModule,
+  ],
+  controllers: [CommentController],
   providers: [CommentService],
 })
 export class CommentModule {}

--- a/apps/backend/src/post/entities/post.entity.ts
+++ b/apps/backend/src/post/entities/post.entity.ts
@@ -10,6 +10,7 @@ import {
 } from "typeorm";
 import { User } from "src/user/entities/user.entity";
 import { Attachment } from "src/attachment/entities/attachment.entity";
+import { PostComment } from "src/comment/entities/post-comment.entity";
 
 export enum PostCategory {
   DUMMY1 = "DUMMY1",
@@ -43,6 +44,9 @@ export class Post {
 
   @OneToMany(() => Attachment, (attachment) => attachment.post)
   attachments: Attachment[];
+
+  @OneToMany(() => PostComment, (comment) => comment.post)
+  comments: PostComment[];
 
   @Column({ name: "like_count", default: 0 })
   likeCount: number;

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -202,7 +202,7 @@ export class PostQueryService {
   async getPost(userId: number, postId: number): Promise<GetPostResult> {
     const post = await this.postRepository.findOne({
       where: { id: postId },
-      relations: { author: true, attachments: true },
+      relations: { author: true, attachments: true, comments: true },
     });
     if (!post) {
       throw new PostNotFoundError();

--- a/apps/backend/src/post/post.controller.ts
+++ b/apps/backend/src/post/post.controller.ts
@@ -148,6 +148,15 @@ export class PostController {
           id: a.id,
           url: attachmentToUrl[a.id],
         })),
+        comments: entry.post.comments.map((c) => ({
+          id: c.id,
+          content: c.content,
+          author: {
+            nickname: c.nickname,
+          },
+          createdAt: c.createdAt,
+          updatedAt: c.updatedAt,
+        })),
         likeCount: entry.post.likeCount,
         isOwner: entry.withUser.isOwner,
         isLiked: entry.withUser.isLiked,

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -23,3 +23,8 @@ export * from "./posts/get-post";
 export * from "./posts/update-post";
 export * from "./posts/set-post-like";
 export * from "./posts/delete-post";
+
+export * from "./post-comments/common";
+export * from "./post-comments/create-comment";
+export * from "./post-comments/update-comment";
+export * from "./post-comments/delete-comment";

--- a/packages/api-types/src/post-comments/common.ts
+++ b/packages/api-types/src/post-comments/common.ts
@@ -1,0 +1,6 @@
+import z from "zod";
+
+export const CommentContentSchema = z.string().min(1).max(200);
+
+export const CommentNotFoundErrorCode = "COMMENT_NOT_FOUND";
+export const NotCommentAuthorErrorCode = "NOT_COMMENT_AUTHOR";

--- a/packages/api-types/src/post-comments/create-comment.ts
+++ b/packages/api-types/src/post-comments/create-comment.ts
@@ -1,0 +1,40 @@
+/*
+ POST /posts/:postId/comments
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import {
+  PostAuthorNicknameSchema,
+  PostNotFoundErrorCode,
+} from "../posts/common";
+import { CommentContentSchema } from "./common";
+
+export const CreateCommentRequestDtoSchema = z.object({
+  nickname: PostAuthorNicknameSchema,
+  content: CommentContentSchema,
+});
+
+export type CreateCommentRequestDto = z.output<
+  typeof CreateCommentRequestDtoSchema
+>;
+
+export const CreateCommentResponseDtoSchema = responseDtoSchema(
+  z.object({
+    id: z.int(),
+  }),
+  z.enum([PostNotFoundErrorCode]),
+);
+
+export type CreateCommentResponseDto = z.output<
+  typeof CreateCommentResponseDtoSchema
+>;
+export type CreateCommentSuccessResponseDto = Extract<
+  CreateCommentResponseDto,
+  { success: true }
+>;
+export type CreateCommentErrorResponseDto = Extract<
+  CreateCommentResponseDto,
+  { success: false }
+>;

--- a/packages/api-types/src/post-comments/delete-comment.ts
+++ b/packages/api-types/src/post-comments/delete-comment.ts
@@ -1,0 +1,30 @@
+/*
+ DELETE /posts/:postId/comments/:commentId
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import { PostNotFoundErrorCode } from "../posts/common";
+import { CommentNotFoundErrorCode, NotCommentAuthorErrorCode } from "./common";
+
+export const DeleteCommentResponseDtoSchema = responseDtoSchema(
+  z.null(),
+  z.enum([
+    PostNotFoundErrorCode,
+    CommentNotFoundErrorCode,
+    NotCommentAuthorErrorCode,
+  ]),
+);
+
+export type DeleteCommentResponseDto = z.output<
+  typeof DeleteCommentResponseDtoSchema
+>;
+export type DeleteCommentSuccessResponseDto = Extract<
+  DeleteCommentResponseDto,
+  { success: true }
+>;
+export type DeleteCommentErrorResponseDto = Extract<
+  DeleteCommentResponseDto,
+  { success: false }
+>;

--- a/packages/api-types/src/post-comments/update-comment.ts
+++ b/packages/api-types/src/post-comments/update-comment.ts
@@ -1,0 +1,42 @@
+/*
+ PATCH /posts/:postId/comments/:commentId
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../helpers";
+import { PostNotFoundErrorCode } from "../posts/common";
+import {
+  CommentContentSchema,
+  CommentNotFoundErrorCode,
+  NotCommentAuthorErrorCode,
+} from "./common";
+
+export const UpdateCommentRequestDtoSchema = z.object({
+  content: CommentContentSchema,
+});
+
+export type UpdateCommentRequestDto = z.output<
+  typeof UpdateCommentRequestDtoSchema
+>;
+
+export const UpdateCommentResponseDtoSchema = responseDtoSchema(
+  z.null(),
+  z.enum([
+    PostNotFoundErrorCode,
+    CommentNotFoundErrorCode,
+    NotCommentAuthorErrorCode,
+  ]),
+);
+
+export type UpdateCommentResponseDto = z.output<
+  typeof UpdateCommentResponseDtoSchema
+>;
+export type UpdateCommentSuccessResponseDto = Extract<
+  UpdateCommentResponseDto,
+  { success: true }
+>;
+export type UpdateCommentErrorResponseDto = Extract<
+  UpdateCommentResponseDto,
+  { success: false }
+>;

--- a/packages/api-types/src/posts/common.ts
+++ b/packages/api-types/src/posts/common.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { dateSerializerCodec } from "../common/codecs";
+import { CommentContentSchema } from "src/post-comments/common";
 
 export const PostContentSchema = z.string().min(1).max(200);
 
@@ -16,7 +17,7 @@ export type AttachmentDto = z.output<typeof AttachmentDtoSchema>;
 
 export const PostAuthorNicknameSchema = z.string().min(2).max(10);
 
-export const PostAuthorDtoSchema = z.object({
+export const AuthorDtoSchema = z.object({
   nickname: PostAuthorNicknameSchema,
 });
 
@@ -24,7 +25,7 @@ export const PostDtoSchema = z.object({
   id: z.int(),
   content: PostContentSchema,
   category: PostCategorySchema,
-  author: PostAuthorDtoSchema,
+  author: AuthorDtoSchema,
   attachments: z.array(AttachmentDtoSchema),
   likeCount: z.int(),
   isOwner: z.boolean(),
@@ -34,6 +35,20 @@ export const PostDtoSchema = z.object({
 });
 
 export type PostDto = z.output<typeof PostDtoSchema>;
+
+export const CommentDtoSchema = z.object({
+  id: z.int(),
+  content: CommentContentSchema,
+  author: AuthorDtoSchema,
+  createdAt: dateSerializerCodec,
+  updatedAt: dateSerializerCodec,
+});
+
+export type CommentDto = z.output<typeof CommentDtoSchema>;
+
+export const PostWithCommentsSchema = PostDtoSchema.extend({
+  comments: z.array(CommentDtoSchema),
+});
 
 // shared error codes
 

--- a/packages/api-types/src/posts/get-post.ts
+++ b/packages/api-types/src/posts/get-post.ts
@@ -5,10 +5,10 @@
 
 import z from "zod";
 import { responseDtoSchema } from "../helpers";
-import { PostDtoSchema, PostNotFoundErrorCode } from "./common";
+import { PostNotFoundErrorCode, PostWithCommentsSchema } from "./common";
 
 export const GetPostResponseDtoSchema = responseDtoSchema(
-  PostDtoSchema,
+  PostWithCommentsSchema,
   z.enum([PostNotFoundErrorCode]),
 );
 


### PR DESCRIPTION
## 요약

- Closes #68 
- 댓글 관련 API endpoint 작성 및 controller 구현을 하였습니다.

## 내용

### `api-types`

- `/posts/:postId/comments/` 하위의 endpoint들을 추가하였습니다.
- `GET /posts/:postId`: `comments` property에서 댓글을 expose 하도록 수정하였습니다.

### `backend`

- `CommentController`를 작성하였습니다.
- `PostQueryService` 및 `PostController`가 `api-types`에서의 변경사항을 반영하도록 수정하였습니다.

## Notes

- `api-types`: common schema 작성 위치와 error code 작성에 대한 리팩토링 작업이 필요해 보입니다.
- `backend`: controller에서의 mapping 코드에 대한 리팩토링이 필요해 보입니다.
- 위 사항들은 separate PR로 올릴 수 있도록 하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comment management functionality: authenticated users can now create new comments on posts, update their existing comments, and delete comments they authored
  * Comments are now displayed when viewing post details, including comment content, author information, and timestamps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->