### PR TITLE
TypeORM explicit id column 추가

### DIFF
--- a/apps/backend/src/attachment/entities/attachment.entity.ts
+++ b/apps/backend/src/attachment/entities/attachment.entity.ts
@@ -21,6 +21,9 @@ export class Attachment {
   @Column({ type: "int", nullable: true })
   index: number | null;
 
+  @Column({ name: "post_id", nullable: true })
+  postId: number | null;
+
   @ManyToOne(() => Post, (post) => post.attachments, {
     nullable: true,
     onDelete: "CASCADE",

--- a/apps/backend/src/auth/refresh-token/refresh-token.entity.ts
+++ b/apps/backend/src/auth/refresh-token/refresh-token.entity.ts
@@ -18,6 +18,9 @@ export class RefreshToken {
   @Column({ type: "timestamptz", name: "expires_at" })
   expiresAt: Date;
 
+  @Column({ name: "user_id" })
+  userId: number;
+
   @ManyToOne(() => User, { onDelete: "CASCADE" })
   @JoinColumn({ name: "user_id" })
   user: User;

--- a/apps/backend/src/auth/refresh-token/refresh-token.service.ts
+++ b/apps/backend/src/auth/refresh-token/refresh-token.service.ts
@@ -37,12 +37,11 @@ export class RefreshTokenService {
   async findUserIdByToken(token: string): Promise<number | null> {
     const refreshToken = await this.refreshTokenRepository.findOne({
       where: { token },
-      relations: { user: true },
     });
     if (!refreshToken || refreshToken.expiresAt < new Date()) {
       return null;
     }
-    return refreshToken.user.id;
+    return refreshToken.userId;
   }
 
   /*
@@ -53,7 +52,7 @@ export class RefreshTokenService {
     const refreshToken = await this.dataSource.transaction(async (manager) => {
       // 2026-03-16: NestJS에서 이게 최선일까?
       const refreshTokenRepository = manager.getRepository(RefreshToken);
-      refreshTokenRepository.delete({ user: { id: userId } });
+      refreshTokenRepository.delete({ userId });
       const refreshToken = await this.createRefreshToken(userId);
       refreshTokenRepository.save(refreshToken);
       return refreshToken;
@@ -77,7 +76,7 @@ export class RefreshTokenService {
     const refreshToken = this.refreshTokenRepository.create({
       token,
       expiresAt,
-      user: { id: userId },
+      userId,
     });
     return refreshToken;
   }

--- a/apps/backend/src/auth/refresh-token/refresh-token.service.ts
+++ b/apps/backend/src/auth/refresh-token/refresh-token.service.ts
@@ -52,9 +52,9 @@ export class RefreshTokenService {
     const refreshToken = await this.dataSource.transaction(async (manager) => {
       // 2026-03-16: NestJS에서 이게 최선일까?
       const refreshTokenRepository = manager.getRepository(RefreshToken);
-      refreshTokenRepository.delete({ userId });
+      await refreshTokenRepository.delete({ userId });
       const refreshToken = await this.createRefreshToken(userId);
-      refreshTokenRepository.save(refreshToken);
+      await refreshTokenRepository.save(refreshToken);
       return refreshToken;
     });
     return refreshToken.token;

--- a/apps/backend/src/comment/comment.service.ts
+++ b/apps/backend/src/comment/comment.service.ts
@@ -50,8 +50,8 @@ export class CommentService {
 
     return this.commentRepository.save(
       this.commentRepository.create({
-        post: { id: postId },
-        author: { id: userId },
+        postId,
+        authorId: userId,
         nickname,
         content,
         deletedAt: null,
@@ -77,7 +77,7 @@ export class CommentService {
     }
 
     const comment = await this.commentRepository.findOne({
-      where: { id: commentId, post: { id: postId }, deletedAt: IsNull() },
+      where: { id: commentId, postId, deletedAt: IsNull() },
     });
 
     if (!comment) {
@@ -106,7 +106,7 @@ export class CommentService {
     }
 
     const comment = await this.commentRepository.findOne({
-      where: { id: commentId, post: { id: postId }, deletedAt: IsNull() },
+      where: { id: commentId, postId, deletedAt: IsNull() },
     });
 
     if (!comment) {
@@ -121,7 +121,7 @@ export class CommentService {
       { id: commentId },
       {
         deletedAt: new Date(),
-        deletedBy: { id: userId },
+        deletedById: userId,
         deletionType: DeletionType.AUTHOR,
       },
     );

--- a/apps/backend/src/comment/comment.service.ts
+++ b/apps/backend/src/comment/comment.service.ts
@@ -78,14 +78,13 @@ export class CommentService {
 
     const comment = await this.commentRepository.findOne({
       where: { id: commentId, post: { id: postId }, deletedAt: IsNull() },
-      relations: { author: true },
     });
 
     if (!comment) {
       throw new CommentNotFoundError();
     }
 
-    if (comment.author.id !== userId) {
+    if (comment.authorId !== userId) {
       throw new NotCommentAuthorError();
     }
 
@@ -108,14 +107,13 @@ export class CommentService {
 
     const comment = await this.commentRepository.findOne({
       where: { id: commentId, post: { id: postId }, deletedAt: IsNull() },
-      relations: { author: true },
     });
 
     if (!comment) {
       throw new CommentNotFoundError();
     }
 
-    if (comment.author.id !== userId) {
+    if (comment.authorId !== userId) {
       throw new NotCommentAuthorError();
     }
 

--- a/apps/backend/src/comment/entities/post-comment.entity.ts
+++ b/apps/backend/src/comment/entities/post-comment.entity.ts
@@ -26,9 +26,15 @@ export class PostComment {
   @Column({ type: "text" })
   content: string;
 
+  @Column({ name: "post_id" })
+  postId: number;
+
   @ManyToOne(() => Post, { onDelete: "CASCADE" })
   @JoinColumn({ name: "post_id" })
   post: Post;
+
+  @Column({ name: "author_id" })
+  authorId: number;
 
   @ManyToOne(() => User)
   @JoinColumn({ name: "author_id" })
@@ -42,6 +48,9 @@ export class PostComment {
 
   @Column({ type: "timestamptz", name: "deleted_at", nullable: true })
   deletedAt: Date | null;
+
+  @Column({ name: "deleted_by", nullable: true })
+  deletedById: number | null;
 
   @ManyToOne(() => User, { nullable: true })
   @JoinColumn({ name: "deleted_by" })

--- a/apps/backend/src/post/entities/post-like.entity.ts
+++ b/apps/backend/src/post/entities/post-like.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 import { Post } from "./post.entity";
 import { User } from "src/user/entities/user.entity";
 
@@ -7,9 +13,15 @@ export class PostLike {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column({ name: "post_id" })
+  postId: number;
+
   @ManyToOne(() => Post, { onDelete: "CASCADE" })
   @JoinColumn({ name: "post_id" })
   post: Post;
+
+  @Column({ name: "user_id" })
+  userId: number;
 
   @ManyToOne(() => User, { onDelete: "CASCADE" })
   @JoinColumn({ name: "user_id" })

--- a/apps/backend/src/post/entities/post.entity.ts
+++ b/apps/backend/src/post/entities/post.entity.ts
@@ -32,6 +32,9 @@ export class Post {
   @Column()
   nickname: string;
 
+  @Column({ name: "author_id" })
+  authorId: number;
+
   @ManyToOne(() => User)
   @JoinColumn({ name: "author_id" })
   author: User;

--- a/apps/backend/src/post/post-mutation.service.ts
+++ b/apps/backend/src/post/post-mutation.service.ts
@@ -85,14 +85,14 @@ export class PostMutationService {
 
     const post = await this.postRepository.findOne({
       where: { id: postId },
-      relations: { author: true, attachments: true },
+      relations: { attachments: true },
     });
 
     if (!post) {
       throw new PostNotFoundError();
     }
 
-    if (post.author.id !== userId) {
+    if (post.authorId !== userId) {
       throw new NotPostAuthorError();
     }
 
@@ -178,14 +178,14 @@ export class PostMutationService {
   async deletePost(userId: number, postId: number): Promise<void> {
     const post = await this.postRepository.findOne({
       where: { id: postId },
-      relations: { author: true, attachments: true },
+      relations: { attachments: true },
     });
 
     if (!post) {
       throw new PostNotFoundError();
     }
 
-    if (post.author.id !== userId) {
+    if (post.authorId !== userId) {
       throw new NotPostAuthorError();
     }
 

--- a/apps/backend/src/post/post-mutation.service.ts
+++ b/apps/backend/src/post/post-mutation.service.ts
@@ -60,7 +60,7 @@ export class PostMutationService {
 
     const post = await this.postRepository.save(
       this.postRepository.create({
-        author: { id: userId },
+        authorId: userId,
         content,
         nickname,
         category,
@@ -142,8 +142,8 @@ export class PostMutationService {
     }
 
     const postLikeExists = await this.postLikeRepository.existsBy({
-      user: { id: userId },
-      post: { id: postId },
+      userId,
+      postId,
     });
 
     await this.dataSource.transaction(async (manager) => {
@@ -155,8 +155,8 @@ export class PostMutationService {
 
         await postLikeRepository.save(
           this.postLikeRepository.create({
-            user: { id: userId },
-            post: { id: postId },
+            userId,
+            postId,
           }),
         );
       }
@@ -165,8 +165,8 @@ export class PostMutationService {
         await postRepository.decrement({ id: postId }, "likeCount", 1);
 
         await postLikeRepository.delete({
-          user: { id: userId },
-          post: { id: postId },
+          userId,
+          postId,
         });
       }
     });

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -160,7 +160,7 @@ export class PostQueryService {
         ? (
             await this.postLikeRepository.find({
               where: {
-                user: { id: userId },
+                userId,
                 post: { id: In(postIds) },
               },
             })
@@ -208,8 +208,8 @@ export class PostQueryService {
     }
 
     const isLiked = await this.postLikeRepository.existsBy({
-      user: { id: userId },
-      post: { id: postId },
+      userId,
+      postId,
     });
 
     const attachmentToUrl = this.buildAttachmentToUrl(post.attachments);

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -163,9 +163,8 @@ export class PostQueryService {
                 user: { id: userId },
                 post: { id: In(postIds) },
               },
-              relations: { post: true },
             })
-          ).map((l) => l.post.id)
+          ).map((l) => l.postId)
         : [],
     );
 
@@ -177,7 +176,7 @@ export class PostQueryService {
       entries: posts.map((post) => ({
         post,
         withUser: {
-          isOwner: post.author.id === userId,
+          isOwner: post.authorId === userId,
           isLiked: likedPostIds.has(post.id),
         },
       })),
@@ -219,7 +218,7 @@ export class PostQueryService {
       entry: {
         post,
         withUser: {
-          isOwner: post.author.id === userId,
+          isOwner: post.authorId === userId,
           isLiked,
         },
       },


### PR DESCRIPTION
## 요약

`backend`: TypeORM entity에 id column을 explicit 하게 추가하였습니다.

## 내용

TypeORM에서 다른 entity를 참조할 때, 즉 FK를 지정할 때 참조할 entity를 직접 지정하는 방법이 가장 일반적입니다. 하지만 해당 방식에선 참조하는 entity의 id 값만 필요해도 구현상 join이 들어가는 문제가 발생합니다.

해당 문제를 해결하기 위해, TypeORM entity들의 정의에 FK로 사용되는 id column을 explicit 하게 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Backend now uses direct foreign-key fields for relational data, simplifying internal data access.
* **Bug Fixes**
  * More consistent ownership checks and token handling; fewer redundant relation loads.
* **User Impact**
  * No API changes; expected improvements in request performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->