### PR TITLE
`/auth/login` response 변경

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -85,7 +85,7 @@ export class AuthController {
   async login(
     @ZodBody(LoginRequestDtoSchema) body: LoginRequestDto,
   ): Promise<LoginSuccessResponseDto> {
-    const { tokens } = await this.authService.login(body.email, body.password);
+    const tokens = await this.authService.login(body.email, body.password);
     return {
       success: true,
       data: {

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -85,23 +85,10 @@ export class AuthController {
   async login(
     @ZodBody(LoginRequestDtoSchema) body: LoginRequestDto,
   ): Promise<LoginSuccessResponseDto> {
-    const { user, tokens } = await this.authService.login(
-      body.email,
-      body.password,
-    );
+    const { tokens } = await this.authService.login(body.email, body.password);
     return {
       success: true,
       data: {
-        user: {
-          id: user.id,
-          email: user.email,
-          role: user.role,
-          createdAt: user.createdAt,
-          profile: {
-            nickname: user.userProfile.nickname,
-            age: user.userProfile.age,
-          },
-        },
         accessToken: tokens.accessToken,
         refreshToken: tokens.refreshToken,
       },

--- a/apps/backend/src/auth/auth.service.spec.ts
+++ b/apps/backend/src/auth/auth.service.spec.ts
@@ -387,7 +387,7 @@ describe("AuthService", () => {
   });
 
   describe("login", () => {
-    it("success: 토큰 저장, 유저 및 토큰 반환", async () => {
+    it("success: 토큰 저장 및 반환", async () => {
       // Given: 올바른 이메일 및 비밀번호
       const email = "test@example.com";
       const password = "password";
@@ -397,15 +397,14 @@ describe("AuthService", () => {
       // When: 로그인 시도
       const result = await authService.login(email, password);
 
-      // Then: 토큰 저장, 유저 및 토큰 반환
-      expect(result.user.email).toBe(email);
+      // Then: 토큰 저장 및 반환
       expect(
-        jwtService.verify<AccessTokenPayload>(result.tokens.accessToken).sub,
-      ).toBe(result.user.id);
+        jwtService.verify<AccessTokenPayload>(result.accessToken).sub,
+      ).toBe(user.id);
       const storedToken = await refreshTokenRepository.findOneBy({
-        user: { id: result.user.id },
+        user: { id: user.id },
       });
-      expect(storedToken?.token).toBe(result.tokens.refreshToken);
+      expect(storedToken?.token).toBe(result.refreshToken);
     });
 
     it("존재하지 않는 유저 처리", async () => {

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -7,7 +7,6 @@ import { SignUpTokenService } from "./sign-up-token/sign-up-token.service";
 import { AccessTokenService } from "./access-token/access-token.service";
 import { RefreshTokenService } from "./refresh-token/refresh-token.service";
 import { JsonWebTokenError } from "@nestjs/jwt";
-import { User } from "src/user/entities/user.entity";
 import { bcryptHash, bcryptCompare } from "./bcrypt.helper";
 import {
   EmailAlreadyExistsError,
@@ -22,11 +21,6 @@ import {
 export type TokenPair = {
   accessToken: string;
   refreshToken: string;
-};
-
-export type LoginResult = {
-  user: User;
-  tokens: TokenPair;
 };
 
 /**
@@ -130,9 +124,9 @@ export class AuthService {
 
   /**
    * email과 password를 이용해 로그인을 시도한다.
-   * @returns access token 및 refresh token과 user
+   * @returns access token 및 refresh token
    */
-  async login(email: string, password: string): Promise<LoginResult> {
+  async login(email: string, password: string): Promise<TokenPair> {
     const user = await this.userService.findByEmail(email);
     if (!user) throw new InvalidCredentialsError();
 
@@ -143,7 +137,7 @@ export class AuthService {
     const accessToken = this.accessTokenService.sign(user.id);
     const refreshToken = await this.refreshTokenService.issue(user.id);
 
-    return { user, tokens: { accessToken, refreshToken } };
+    return { accessToken, refreshToken };
   }
 
   /**

--- a/packages/api-types/src/auth/login.ts
+++ b/packages/api-types/src/auth/login.ts
@@ -4,7 +4,6 @@
 
 import z from "zod";
 import { responseDtoSchema } from "../helpers";
-import { UserDtoSchema } from "../common/user";
 import { AuthErrorCode } from "../common/error-codes";
 
 export const LoginRequestDtoSchema = z.object({
@@ -16,7 +15,6 @@ export type LoginRequestDto = z.output<typeof LoginRequestDtoSchema>;
 
 export const LoginResponseDtoSchema = responseDtoSchema(
   z.object({
-    user: UserDtoSchema,
     accessToken: z.string(),
     refreshToken: z.string(),
   }),


### PR DESCRIPTION
## 요약

`/auth/login` 의 response schema에서 `user` 프로퍼티는 불필요하다고 판단되어, 이를 삭제하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login endpoint response simplified: it now returns only access and refresh tokens and no longer includes the user profile.
  * Tests and internal handling updated to align with the new response shape; clients should no longer expect a user object in login responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->