### PR TITLE
api-types 빌드 방식 변경

### DIFF
--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -2,15 +2,10 @@
   "name": "@mindseed/api-types",
   "version": "1.0.0",
   "private": true,
-  "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts"
+    "build": "tsup src/index.ts --format esm --dts"
   },
   "dependencies": {
     "zod": "^4.3.6"

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -2,10 +2,15 @@
   "name": "@mindseed/api-types",
   "version": "1.0.0",
   "private": true,
-  "main": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts"
+    "build": "tsup src/index.ts --format esm,cjs --dts"
   },
   "dependencies": {
     "zod": "^4.3.6"


### PR DESCRIPTION
## 요약

기존 `api-types` package는 ESM, CJS export를 둘 다 지원하고 있었습니다. 그러나 현재 프로젝트 스택 상에서 둘 다 지원하는 것은 불필요하다고 생각되었기에, ESM export만 진행하도록 정리하였습니다.

또한 이는 기존 빌드에서 발생하던 warning을 해결합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution configuration and build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->