### PR TITLE
백엔드 service 코드 및 테스트 코드 리팩토링

### DIFF
--- a/apps/backend/src/auth/auth.service.spec.ts
+++ b/apps/backend/src/auth/auth.service.spec.ts
@@ -38,26 +38,6 @@ import { bcryptHash } from "./bcrypt.helper";
 // dependent 한 order
 const entities = [RefreshToken, UserProfile, User];
 
-async function saveTestUser(
-  repository: Repository<User>,
-  email: string,
-  password: string,
-  overrides?: Partial<User>,
-): Promise<User> {
-  return repository.save(
-    repository.create({
-      email,
-      password: await bcryptHash(password),
-      role: UserRole.USER,
-      profile: repository.manager.create(UserProfile, {
-        nickname: "John Doe",
-        age: 20,
-      }),
-      ...overrides,
-    }),
-  );
-}
-
 describe("AuthService", () => {
   let module: TestingModule;
 
@@ -74,6 +54,25 @@ describe("AuthService", () => {
   let redis: InstanceType<typeof IORedisMock>;
   let dataSource: DataSource;
   let dbBackup: PGMem.IBackup;
+
+  async function saveTestUser(
+    email: string,
+    password: string,
+    overrides?: Partial<User>,
+  ): Promise<User> {
+    return userRepository.save(
+      userRepository.create({
+        email,
+        password: await bcryptHash(password),
+        role: UserRole.USER,
+        profile: userRepository.manager.create(UserProfile, {
+          nickname: "John Doe",
+          age: 20,
+        }),
+        ...overrides,
+      }),
+    );
+  }
 
   beforeAll(async () => {
     const { dataSource: ds, backup } = await initializePgMem(entities);
@@ -154,7 +153,7 @@ describe("AuthService", () => {
     it("이메일 중복 처리", async () => {
       // Given: 이미 가입된 이메일인 경우
       const email = "test@example.com";
-      await saveTestUser(userRepository, email, "password");
+      await saveTestUser(email, "password");
 
       // When
       const result = authService.sendVerificationMail(email);
@@ -376,7 +375,7 @@ describe("AuthService", () => {
       const age = 20;
       const signUpToken = signUpTokenService.sign(email);
 
-      await saveTestUser(userRepository, email, "password");
+      await saveTestUser(email, "password");
 
       // When: 회원가입 시도
       const result = authService.completeSignup(
@@ -396,7 +395,7 @@ describe("AuthService", () => {
       // Given: 올바른 이메일 및 비밀번호
       const email = "test@example.com";
       const password = "password";
-      const user = await saveTestUser(userRepository, email, password);
+      const user = await saveTestUser(email, password);
 
       // When: 로그인 시도
       const result = await authService.login(email, password);
@@ -428,7 +427,7 @@ describe("AuthService", () => {
       const email = "test@example.com";
       const expectedPassword = "password";
       const incorrectPassword = "invalid";
-      const user = await saveTestUser(userRepository, email, expectedPassword);
+      const user = await saveTestUser(email, expectedPassword);
 
       // When: 로그인 시도
       const result = authService.login(email, incorrectPassword);
@@ -443,7 +442,7 @@ describe("AuthService", () => {
       // Given: 존재하는 유저에 대한 올바른 refresh token
       const email = "test@example.com";
       const password = "password";
-      const user = await saveTestUser(userRepository, email, password);
+      const user = await saveTestUser(email, password);
       const oldToken = await refreshTokenService.issue(user.id);
 
       // When: refresh 시도

--- a/apps/backend/src/auth/auth.service.spec.ts
+++ b/apps/backend/src/auth/auth.service.spec.ts
@@ -38,18 +38,24 @@ import { bcryptHash } from "./bcrypt.helper";
 // dependent 한 order
 const entities = [RefreshToken, UserProfile, User];
 
-async function createTestUser(email: string, password: string): Promise<User> {
-  const testUserProfile = new UserProfile();
-  testUserProfile.nickname = "John Doe";
-  testUserProfile.age = 20;
-
-  const testUser = new User();
-  testUser.email = email;
-  testUser.password = await bcryptHash(password);
-  testUser.role = UserRole.USER;
-  testUser.profile = testUserProfile;
-
-  return testUser;
+async function saveTestUser(
+  repository: Repository<User>,
+  email: string,
+  password: string,
+  overrides?: Partial<User>,
+): Promise<User> {
+  return repository.save(
+    repository.create({
+      email,
+      password: await bcryptHash(password),
+      role: UserRole.USER,
+      profile: repository.manager.create(UserProfile, {
+        nickname: "John Doe",
+        age: 20,
+      }),
+      ...overrides,
+    }),
+  );
 }
 
 describe("AuthService", () => {
@@ -148,7 +154,7 @@ describe("AuthService", () => {
     it("이메일 중복 처리", async () => {
       // Given: 이미 가입된 이메일인 경우
       const email = "test@example.com";
-      await userRepository.save(await createTestUser(email, "password"));
+      await saveTestUser(userRepository, email, "password");
 
       // When
       const result = authService.sendVerificationMail(email);
@@ -370,8 +376,7 @@ describe("AuthService", () => {
       const age = 20;
       const signUpToken = signUpTokenService.sign(email);
 
-      const existingUser = await createTestUser(email, "password");
-      await userRepository.save<User>(existingUser);
+      await saveTestUser(userRepository, email, "password");
 
       // When: 회원가입 시도
       const result = authService.completeSignup(
@@ -391,8 +396,7 @@ describe("AuthService", () => {
       // Given: 올바른 이메일 및 비밀번호
       const email = "test@example.com";
       const password = "password";
-      const user = await createTestUser(email, password);
-      await userRepository.save(user);
+      const user = await saveTestUser(userRepository, email, password);
 
       // When: 로그인 시도
       const result = await authService.login(email, password);
@@ -424,8 +428,7 @@ describe("AuthService", () => {
       const email = "test@example.com";
       const expectedPassword = "password";
       const incorrectPassword = "invalid";
-      const user = await createTestUser(email, expectedPassword);
-      await userRepository.save(user);
+      const user = await saveTestUser(userRepository, email, expectedPassword);
 
       // When: 로그인 시도
       const result = authService.login(email, incorrectPassword);
@@ -440,9 +443,7 @@ describe("AuthService", () => {
       // Given: 존재하는 유저에 대한 올바른 refresh token
       const email = "test@example.com";
       const password = "password";
-      const user = await userRepository.save(
-        await createTestUser(email, password),
-      );
+      const user = await saveTestUser(userRepository, email, password);
       const oldToken = await refreshTokenService.issue(user.id);
 
       // When: refresh 시도

--- a/apps/backend/src/comment/comment.service.spec.ts
+++ b/apps/backend/src/comment/comment.service.spec.ts
@@ -14,58 +14,6 @@ import { Attachment } from "src/attachment/entities/attachment.entity";
 
 const entities = [UserProfile, User, Attachment, PostComment, Post];
 
-let userCounter = 0;
-
-async function saveTestUser(
-  repository: Repository<User>,
-  overrides?: Partial<User>,
-): Promise<User> {
-  return repository.save(
-    repository.create({
-      email: `user${++userCounter}@test.com`,
-      password: "password",
-      role: UserRole.USER,
-      ...overrides,
-    }),
-  );
-}
-
-async function saveTestPost(
-  repository: Repository<Post>,
-  userId: number,
-  overrides?: Partial<Post>,
-): Promise<Post> {
-  return repository.save(
-    repository.create({
-      content: "test content",
-      category: PostCategory.DUMMY1,
-      nickname: "testnick",
-      author: { id: userId } as User,
-      ...overrides,
-    }),
-  );
-}
-
-async function saveTestComment(
-  repository: Repository<PostComment>,
-  postId: number,
-  authorId: number,
-  overrides?: Partial<PostComment>,
-): Promise<PostComment> {
-  return repository.save(
-    repository.create({
-      content: "test comment",
-      nickname: "testnick",
-      post: { id: postId } as Post,
-      author: { id: authorId } as User,
-      deletedAt: null,
-      deletedBy: null,
-      deletionType: null,
-      ...overrides,
-    }),
-  );
-}
-
 describe("CommentService", () => {
   let module: TestingModule;
   let commentService: CommentService;
@@ -74,6 +22,53 @@ describe("CommentService", () => {
   let userRepository: Repository<User>;
   let dataSource: DataSource;
   let dbBackup: PGMem.IBackup;
+
+  let userCounter = 0;
+
+  async function saveTestUser(overrides?: Partial<User>): Promise<User> {
+    return userRepository.save(
+      userRepository.create({
+        email: `user${++userCounter}@test.com`,
+        password: "password",
+        role: UserRole.USER,
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestPost(
+    userId: number,
+    overrides?: Partial<Post>,
+  ): Promise<Post> {
+    return postRepository.save(
+      postRepository.create({
+        content: "test content",
+        category: PostCategory.DUMMY1,
+        nickname: "testnick",
+        author: { id: userId } as User,
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestComment(
+    postId: number,
+    authorId: number,
+    overrides?: Partial<PostComment>,
+  ): Promise<PostComment> {
+    return commentRepository.save(
+      commentRepository.create({
+        content: "test comment",
+        nickname: "testnick",
+        post: { id: postId } as Post,
+        author: { id: authorId } as User,
+        deletedAt: null,
+        deletedBy: null,
+        deletionType: null,
+        ...overrides,
+      }),
+    );
+  }
 
   beforeAll(async () => {
     const { dataSource: ds, backup } = await initializePgMem(entities);
@@ -117,8 +112,8 @@ describe("CommentService", () => {
   describe("createComment", () => {
     it("success: 댓글 저장", async () => {
       // Given: 글이 존재하는 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
 
       // When: 댓글 생성 시도
       const comment = await commentService.createComment({
@@ -137,7 +132,7 @@ describe("CommentService", () => {
 
     it("존재하지 않는 글 처리", async () => {
       // Given: 글이 존재하지 않는 경우
-      const user = await saveTestUser(userRepository);
+      const user = await saveTestUser();
       const nonExistentPostId = 0;
 
       // When: 댓글 생성 시도
@@ -156,13 +151,9 @@ describe("CommentService", () => {
   describe("updateComment", () => {
     it("success: 댓글 업데이트", async () => {
       // Given: 댓글이 존재하며, 사용자가 댓글의 작성자인 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const comment = await saveTestComment(
-        commentRepository,
-        post.id,
-        user.id,
-      );
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const comment = await saveTestComment(post.id, user.id);
       const newContent = "new content";
 
       // When: 댓글 업데이트 시도
@@ -184,7 +175,7 @@ describe("CommentService", () => {
 
     it("존재하지 않는 글 처리", async () => {
       // Given: 글이 존재하지 않는 경우
-      const user = await saveTestUser(userRepository);
+      const user = await saveTestUser();
       const nonExistentPostId = 0;
       const newContent = "new content";
 
@@ -202,8 +193,8 @@ describe("CommentService", () => {
 
     it("DB에 존재하지 않는 댓글 처리", async () => {
       // Given: 글은 존재하지만 댓글이 존재하지 않는 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
       const nonExistentCommentId = 0;
       const newContent = "new content";
 
@@ -221,14 +212,10 @@ describe("CommentService", () => {
 
     it("해당 글의 댓글이 아닌 경우 처리", async () => {
       // Given: 댓글이 존재하지만, 해당 글의 댓글이 아닌 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const otherPost = await saveTestPost(postRepository, user.id);
-      const comment = await saveTestComment(
-        commentRepository,
-        otherPost.id,
-        user.id,
-      );
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const otherPost = await saveTestPost(user.id);
+      const comment = await saveTestComment(otherPost.id, user.id);
       const newContent = "new content";
 
       // When: 댓글 업데이트 시도
@@ -245,18 +232,13 @@ describe("CommentService", () => {
 
     it("삭제된 댓글 처리", async () => {
       // Given: 댓글이 삭제된 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const comment = await saveTestComment(
-        commentRepository,
-        post.id,
-        user.id,
-        {
-          deletedAt: new Date(),
-          deletedBy: user,
-          deletionType: DeletionType.AUTHOR,
-        },
-      );
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const comment = await saveTestComment(post.id, user.id, {
+        deletedAt: new Date(),
+        deletedBy: user,
+        deletionType: DeletionType.AUTHOR,
+      });
       const newContent = "new content";
 
       // When: 댓글 업데이트 시도
@@ -273,14 +255,10 @@ describe("CommentService", () => {
 
     it("댓글 작성자가 아닌 경우 처리", async () => {
       // Given: 댓글이 존재하지만, 사용자가 댓글 작성자가 아닌 경우
-      const user = await saveTestUser(userRepository);
-      const otherUser = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const comment = await saveTestComment(
-        commentRepository,
-        post.id,
-        otherUser.id,
-      );
+      const user = await saveTestUser();
+      const otherUser = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const comment = await saveTestComment(post.id, otherUser.id);
       const newContent = "new content";
 
       // When: 댓글 업데이트 시도
@@ -299,13 +277,9 @@ describe("CommentService", () => {
   describe("deleteComment", () => {
     it("success: 댓글 삭제 column 업데이트", async () => {
       // Given: 댓글이 존재하며, 사용자가 댓글 작성자인 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const comment = await saveTestComment(
-        commentRepository,
-        post.id,
-        user.id,
-      );
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const comment = await saveTestComment(post.id, user.id);
 
       // When: 댓글 삭제 시도
       await commentService.deleteComment(post.id, comment.id, user.id);
@@ -323,7 +297,7 @@ describe("CommentService", () => {
 
     it("존재하지 않는 글 처리", async () => {
       // Given: 글이 존재하지 않는 경우
-      const user = await saveTestUser(userRepository);
+      const user = await saveTestUser();
       const nonExistentPostId = 0;
 
       // When: 댓글 삭제 시도
@@ -339,8 +313,8 @@ describe("CommentService", () => {
 
     it("DB에 존재하지 않는 댓글 처리", async () => {
       // Given: 글은 존재하지만 댓글이 존재하지 않는 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
       const nonExistentCommentId = 0;
 
       // When: 댓글 삭제 시도
@@ -356,14 +330,10 @@ describe("CommentService", () => {
 
     it("해당 글의 댓글이 아닌 경우 처리", async () => {
       // Given: 댓글이 존재하지만, 해당 글의 댓글이 아닌 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const otherPost = await saveTestPost(postRepository, user.id);
-      const comment = await saveTestComment(
-        commentRepository,
-        otherPost.id,
-        user.id,
-      );
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const otherPost = await saveTestPost(user.id);
+      const comment = await saveTestComment(otherPost.id, user.id);
 
       // When: 댓글 삭제 시도
       const result = commentService.deleteComment(post.id, comment.id, user.id);
@@ -374,18 +344,13 @@ describe("CommentService", () => {
 
     it("삭제된 댓글 처리", async () => {
       // Given: 댓글이 삭제된 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const comment = await saveTestComment(
-        commentRepository,
-        post.id,
-        user.id,
-        {
-          deletedAt: new Date(),
-          deletedBy: user,
-          deletionType: DeletionType.AUTHOR,
-        },
-      );
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const comment = await saveTestComment(post.id, user.id, {
+        deletedAt: new Date(),
+        deletedBy: user,
+        deletionType: DeletionType.AUTHOR,
+      });
 
       // When: 댓글 삭제 시도
       const result = commentService.deleteComment(post.id, comment.id, user.id);
@@ -396,14 +361,10 @@ describe("CommentService", () => {
 
     it("댓글 작성자가 아닌 경우 처리", async () => {
       // Given: 댓글이 존재하지만, 사용자가 댓글 작성자가 아닌 경우
-      const user = await saveTestUser(userRepository);
-      const otherUser = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const comment = await saveTestComment(
-        commentRepository,
-        post.id,
-        otherUser.id,
-      );
+      const user = await saveTestUser();
+      const otherUser = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const comment = await saveTestComment(post.id, otherUser.id);
 
       // When: 댓글 삭제 시도
       const result = commentService.deleteComment(post.id, comment.id, user.id);

--- a/apps/backend/src/common/types/pagination.ts
+++ b/apps/backend/src/common/types/pagination.ts
@@ -1,0 +1,23 @@
+export type CursorPaginationOptions<OrderBy extends string> = {
+  cursor?: string;
+  limit: number;
+  orderBy: OrderBy;
+  orderDirection: "asc" | "desc";
+};
+
+export type CursorPaginationResult<Item> = {
+  items: Item[];
+  nextCursor?: string;
+};
+
+export type OffsetPaginationOptions<OrderBy extends string> = {
+  offset: number;
+  limit: number;
+  orderBy: OrderBy;
+  orderDirection: "asc" | "desc";
+};
+
+export type OffsetPaginationResult<Item> = {
+  items: Item[];
+  hasNext: boolean;
+};

--- a/apps/backend/src/mission/mission-participation.service.spec.ts
+++ b/apps/backend/src/mission/mission-participation.service.spec.ts
@@ -34,35 +34,28 @@ const entities = [UserProfile, User, Mission, MissionAssignment];
 let userCounter = 0;
 
 async function saveTestUser(
-  repository: Repository<User>,
-  overrides?: Partial<User>,
+  userRepository: Repository<User>,
+  userProfileRepository: Repository<UserProfile>,
+  overrides?: { level?: number; points?: number },
 ): Promise<User> {
-  return repository.save(
-    repository.create({
+  const user = await userRepository.save(
+    userRepository.create({
       email: `user${++userCounter}@test.com`,
       password: "password",
       role: UserRole.USER,
-      ...overrides,
     }),
   );
-}
-
-async function saveTestUserProfile(
-  repository: Repository<UserProfile>,
-  user: User,
-  overrides?: Partial<UserProfile>,
-): Promise<UserProfile> {
-  return repository.save(
-    repository.create({
+  await userProfileRepository.save(
+    userProfileRepository.create({
       user,
       nickname: "testnick",
       age: 20,
-      points: 0,
-      level: 0,
+      level: overrides?.level ?? 0,
+      points: overrides?.points ?? 0,
       characterIndex: 0,
-      ...overrides,
     }),
   );
+  return user;
 }
 
 async function saveTestMission(
@@ -166,8 +159,7 @@ describe("MissionParticipationService", () => {
       // Given: 날짜
       const date = new Date("2025-01-15T00:00:00Z");
       const otherDate = new Date("2025-01-16T00:00:00Z");
-      const user = await saveTestUser(userRepository);
-      await saveTestUserProfile(userProfileRepository, user);
+      const user = await saveTestUser(userRepository, userProfileRepository);
       const mission1 = await saveTestMission(missionRepository);
       const mission2 = await saveTestMission(missionRepository);
       const assignment1 = await saveTestAssignment(
@@ -208,8 +200,7 @@ describe("MissionParticipationService", () => {
     it("success: 최대 레벨이 아닌 경우 처리", async () => {
       // Given: 최대 레벨이 아닌 사용자, 현재 날짜에 대한 완료하지 않은
       // assignment
-      const user = await saveTestUser(userRepository);
-      await saveTestUserProfile(userProfileRepository, user, {
+      const user = await saveTestUser(userRepository, userProfileRepository, {
         level: 1,
         points: 0,
       });
@@ -249,8 +240,7 @@ describe("MissionParticipationService", () => {
     it("success: 레벨업이 발생한 경우 처리", async () => {
       // Given: 최대 레벨이 아니며 레벨업 예정인 사용자, 현재 날짜에 대한
       // 완료하지 않은 assignment
-      const user = await saveTestUser(userRepository);
-      await saveTestUserProfile(userProfileRepository, user, {
+      const user = await saveTestUser(userRepository, userProfileRepository, {
         level: 1,
         points: 90,
       });
@@ -290,8 +280,7 @@ describe("MissionParticipationService", () => {
     it("success: 최대 레벨인 경우 처리", async () => {
       // Given: 최대 레벨인 사용자, 현재 날짜에 대한
       // 완료하지 않은 assignment
-      const user = await saveTestUser(userRepository);
-      await saveTestUserProfile(userProfileRepository, user, {
+      const user = await saveTestUser(userRepository, userProfileRepository, {
         level: testMaxLevel,
         points: 0,
       });
@@ -330,10 +319,11 @@ describe("MissionParticipationService", () => {
 
     it("사용자에 대해 존재하지 않는 assignment 처리", async () => {
       // Given: 사용자에 대해 존재하지 않는 assignment
-      const user = await saveTestUser(userRepository);
-      await saveTestUserProfile(userProfileRepository, user);
-      const otherUser = await saveTestUser(userRepository);
-      await saveTestUserProfile(userProfileRepository, otherUser);
+      const user = await saveTestUser(userRepository, userProfileRepository);
+      const otherUser = await saveTestUser(
+        userRepository,
+        userProfileRepository,
+      );
       const currentDate = new Date("2025-01-15T00:00:00Z");
       const mission = await saveTestMission(missionRepository);
       const otherAssignment = await saveTestAssignment(
@@ -356,8 +346,7 @@ describe("MissionParticipationService", () => {
 
     it("주어진 날짜에 대한 assignment가 아닌 경우 처리", async () => {
       // Given: 주어진 날짜에 대해 존재하지 않는 assignment
-      const user = await saveTestUser(userRepository);
-      await saveTestUserProfile(userProfileRepository, user);
+      const user = await saveTestUser(userRepository, userProfileRepository);
       const assignmentDate = new Date("2025-01-14T00:00:00Z");
       const currentDate = new Date("2025-01-15T00:00:00Z");
       const mission = await saveTestMission(missionRepository);
@@ -381,8 +370,7 @@ describe("MissionParticipationService", () => {
 
     it("이미 완료한 assignment 처리", async () => {
       // Given: 이미 완료한 assignment
-      const user = await saveTestUser(userRepository);
-      await saveTestUserProfile(userProfileRepository, user);
+      const user = await saveTestUser(userRepository, userProfileRepository);
       const currentDate = new Date("2025-01-15T00:00:00Z");
       const mission = await saveTestMission(missionRepository);
       const assignment = await saveTestAssignment(

--- a/apps/backend/src/mission/mission-participation.service.spec.ts
+++ b/apps/backend/src/mission/mission-participation.service.spec.ts
@@ -31,74 +31,6 @@ const testPointsForNextLevel: PointsForNextLevel = {
 
 const entities = [UserProfile, User, Mission, MissionAssignment];
 
-let userCounter = 0;
-
-async function saveTestUser(
-  userRepository: Repository<User>,
-  userProfileRepository: Repository<UserProfile>,
-  overrides?: { level?: number; points?: number },
-): Promise<User> {
-  const user = await userRepository.save(
-    userRepository.create({
-      email: `user${++userCounter}@test.com`,
-      password: "password",
-      role: UserRole.USER,
-    }),
-  );
-  await userProfileRepository.save(
-    userProfileRepository.create({
-      user,
-      nickname: "testnick",
-      age: 20,
-      level: overrides?.level ?? 0,
-      points: overrides?.points ?? 0,
-      characterIndex: 0,
-    }),
-  );
-  return user;
-}
-
-async function saveTestMission(
-  repository: Repository<Mission>,
-  overrides?: Partial<Mission>,
-): Promise<Mission> {
-  return repository.save(
-    repository.create({
-      title: "test mission",
-      description: "test description",
-      minLevel: 0,
-      category: TestCategory.ANXIETY,
-      points: 10,
-      ...overrides,
-    }),
-  );
-}
-
-async function saveTestAssignment(
-  repository: Repository<MissionAssignment>,
-  userId: number,
-  missionId: number,
-  dueDate: Date,
-  overrides?: Partial<MissionAssignment>,
-): Promise<MissionAssignment> {
-  const availableFrom = new Date(dueDate);
-  availableFrom.setUTCHours(0, 0, 0, 0);
-  const availableUntil = new Date(dueDate);
-  availableUntil.setUTCHours(23, 59, 59, 999);
-
-  return repository.save(
-    repository.create({
-      userId,
-      missionId,
-      availableFrom,
-      availableUntil,
-      status: MissionAssignmentStatus.UNCOMPLETED,
-      completedAt: null,
-      ...overrides,
-    }),
-  );
-}
-
 describe("MissionParticipationService", () => {
   let module: TestingModule;
   let missionParticipationService: MissionParticipationService;
@@ -108,6 +40,71 @@ describe("MissionParticipationService", () => {
   let userProfileRepository: Repository<UserProfile>;
   let dataSource: DataSource;
   let dbBackup: PGMem.IBackup;
+
+  let userCounter = 0;
+
+  async function saveTestUser(overrides?: {
+    level?: number;
+    points?: number;
+  }): Promise<User> {
+    const user = await userRepository.save(
+      userRepository.create({
+        email: `user${++userCounter}@test.com`,
+        password: "password",
+        role: UserRole.USER,
+      }),
+    );
+    await userProfileRepository.save(
+      userProfileRepository.create({
+        user,
+        nickname: "testnick",
+        age: 20,
+        level: overrides?.level ?? 0,
+        points: overrides?.points ?? 0,
+        characterIndex: 0,
+      }),
+    );
+    return user;
+  }
+
+  async function saveTestMission(
+    overrides?: Partial<Mission>,
+  ): Promise<Mission> {
+    return missionRepository.save(
+      missionRepository.create({
+        title: "test mission",
+        description: "test description",
+        minLevel: 0,
+        category: TestCategory.ANXIETY,
+        points: 10,
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestAssignment(
+    userId: number,
+    missionId: number,
+    dueDate: Date,
+    overrides?: Partial<MissionAssignment>,
+  ): Promise<MissionAssignment> {
+    const availableFrom = new Date(dueDate);
+    availableFrom.setUTCHours(0, 0, 0, 0);
+    const availableUntil = new Date(dueDate);
+    availableUntil.setUTCHours(23, 59, 59, 999);
+
+    return missionAssignmentRepository.save(
+      missionAssignmentRepository.create({
+        userId,
+        missionId,
+        availableFrom,
+        availableUntil,
+        status: MissionAssignmentStatus.UNCOMPLETED,
+        completedAt: null,
+        ...overrides,
+      }),
+    );
+  }
 
   beforeAll(async () => {
     const { dataSource: ds, backup } = await initializePgMem(entities);
@@ -159,27 +156,12 @@ describe("MissionParticipationService", () => {
       // Given: 날짜
       const date = new Date("2025-01-15T00:00:00Z");
       const otherDate = new Date("2025-01-16T00:00:00Z");
-      const user = await saveTestUser(userRepository, userProfileRepository);
-      const mission1 = await saveTestMission(missionRepository);
-      const mission2 = await saveTestMission(missionRepository);
-      const assignment1 = await saveTestAssignment(
-        missionAssignmentRepository,
-        user.id,
-        mission1.id,
-        date,
-      );
-      const assignment2 = await saveTestAssignment(
-        missionAssignmentRepository,
-        user.id,
-        mission2.id,
-        date,
-      );
-      await saveTestAssignment(
-        missionAssignmentRepository,
-        user.id,
-        mission1.id,
-        otherDate,
-      );
+      const user = await saveTestUser();
+      const mission1 = await saveTestMission();
+      const mission2 = await saveTestMission();
+      const assignment1 = await saveTestAssignment(user.id, mission1.id, date);
+      const assignment2 = await saveTestAssignment(user.id, mission2.id, date);
+      await saveTestAssignment(user.id, mission1.id, otherDate);
 
       // When: assignmeent 목록 조회 시도
       const result =
@@ -200,14 +182,10 @@ describe("MissionParticipationService", () => {
     it("success: 최대 레벨이 아닌 경우 처리", async () => {
       // Given: 최대 레벨이 아닌 사용자, 현재 날짜에 대한 완료하지 않은
       // assignment
-      const user = await saveTestUser(userRepository, userProfileRepository, {
-        level: 1,
-        points: 0,
-      });
+      const user = await saveTestUser({ level: 1, points: 0 });
       const currentDate = new Date("2025-01-15T00:00:00Z");
-      const mission = await saveTestMission(missionRepository, { points: 10 });
+      const mission = await saveTestMission({ points: 10 });
       const assignment = await saveTestAssignment(
-        missionAssignmentRepository,
         user.id,
         mission.id,
         currentDate,
@@ -240,14 +218,10 @@ describe("MissionParticipationService", () => {
     it("success: 레벨업이 발생한 경우 처리", async () => {
       // Given: 최대 레벨이 아니며 레벨업 예정인 사용자, 현재 날짜에 대한
       // 완료하지 않은 assignment
-      const user = await saveTestUser(userRepository, userProfileRepository, {
-        level: 1,
-        points: 90,
-      });
+      const user = await saveTestUser({ level: 1, points: 90 });
       const currentDate = new Date("2025-01-15T00:00:00Z");
-      const mission = await saveTestMission(missionRepository, { points: 10 });
+      const mission = await saveTestMission({ points: 10 });
       const assignment = await saveTestAssignment(
-        missionAssignmentRepository,
         user.id,
         mission.id,
         currentDate,
@@ -280,14 +254,10 @@ describe("MissionParticipationService", () => {
     it("success: 최대 레벨인 경우 처리", async () => {
       // Given: 최대 레벨인 사용자, 현재 날짜에 대한
       // 완료하지 않은 assignment
-      const user = await saveTestUser(userRepository, userProfileRepository, {
-        level: testMaxLevel,
-        points: 0,
-      });
+      const user = await saveTestUser({ level: testMaxLevel, points: 0 });
       const currentDate = new Date("2025-01-15T00:00:00Z");
-      const mission = await saveTestMission(missionRepository, { points: 10 });
+      const mission = await saveTestMission({ points: 10 });
       const assignment = await saveTestAssignment(
-        missionAssignmentRepository,
         user.id,
         mission.id,
         currentDate,
@@ -319,15 +289,11 @@ describe("MissionParticipationService", () => {
 
     it("사용자에 대해 존재하지 않는 assignment 처리", async () => {
       // Given: 사용자에 대해 존재하지 않는 assignment
-      const user = await saveTestUser(userRepository, userProfileRepository);
-      const otherUser = await saveTestUser(
-        userRepository,
-        userProfileRepository,
-      );
+      const user = await saveTestUser();
+      const otherUser = await saveTestUser();
       const currentDate = new Date("2025-01-15T00:00:00Z");
-      const mission = await saveTestMission(missionRepository);
+      const mission = await saveTestMission();
       const otherAssignment = await saveTestAssignment(
-        missionAssignmentRepository,
         otherUser.id,
         mission.id,
         currentDate,
@@ -346,12 +312,11 @@ describe("MissionParticipationService", () => {
 
     it("주어진 날짜에 대한 assignment가 아닌 경우 처리", async () => {
       // Given: 주어진 날짜에 대해 존재하지 않는 assignment
-      const user = await saveTestUser(userRepository, userProfileRepository);
+      const user = await saveTestUser();
       const assignmentDate = new Date("2025-01-14T00:00:00Z");
       const currentDate = new Date("2025-01-15T00:00:00Z");
-      const mission = await saveTestMission(missionRepository);
+      const mission = await saveTestMission();
       const assignment = await saveTestAssignment(
-        missionAssignmentRepository,
         user.id,
         mission.id,
         assignmentDate,
@@ -370,11 +335,10 @@ describe("MissionParticipationService", () => {
 
     it("이미 완료한 assignment 처리", async () => {
       // Given: 이미 완료한 assignment
-      const user = await saveTestUser(userRepository, userProfileRepository);
+      const user = await saveTestUser();
       const currentDate = new Date("2025-01-15T00:00:00Z");
-      const mission = await saveTestMission(missionRepository);
+      const mission = await saveTestMission();
       const assignment = await saveTestAssignment(
-        missionAssignmentRepository,
         user.id,
         mission.id,
         currentDate,

--- a/apps/backend/src/post/post-mutation.service.spec.ts
+++ b/apps/backend/src/post/post-mutation.service.spec.ts
@@ -22,53 +22,6 @@ import { PostComment } from "src/comment/entities/post-comment.entity";
 
 const entities = [UserProfile, User, PostComment, Post, PostLike, Attachment];
 
-let userCounter = 0;
-
-async function saveTestUser(
-  repository: Repository<User>,
-  overrides?: Partial<User>,
-): Promise<User> {
-  return repository.save(
-    repository.create({
-      email: `user${++userCounter}@test.com`,
-      password: "password",
-      role: UserRole.USER,
-      ...overrides,
-    }),
-  );
-}
-
-async function saveTestPost(
-  repository: Repository<Post>,
-  userId: number,
-  overrides?: Partial<Post>,
-): Promise<Post> {
-  return repository.save(
-    repository.create({
-      content: "test content",
-      category: PostCategory.DUMMY1,
-      nickname: "testnick",
-      author: { id: userId } as User,
-      ...overrides,
-    }),
-  );
-}
-
-async function saveTestAttachment(
-  repository: Repository<Attachment>,
-  overrides?: Partial<Attachment>,
-): Promise<Attachment> {
-  return repository.save(
-    repository.create({
-      confirmed: true,
-      s3Key: `attachments/${randomUUID()}`,
-      index: null,
-      post: null,
-      ...overrides,
-    }),
-  );
-}
-
 describe("PostMutationService", () => {
   let module: TestingModule;
   let postMutationService: PostMutationService;
@@ -79,6 +32,48 @@ describe("PostMutationService", () => {
   let fakeS3: FakeS3StorageService;
   let dataSource: DataSource;
   let dbBackup: PGMem.IBackup;
+
+  let userCounter = 0;
+
+  async function saveTestUser(overrides?: Partial<User>): Promise<User> {
+    return userRepository.save(
+      userRepository.create({
+        email: `user${++userCounter}@test.com`,
+        password: "password",
+        role: UserRole.USER,
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestPost(
+    userId: number,
+    overrides?: Partial<Post>,
+  ): Promise<Post> {
+    return postRepository.save(
+      postRepository.create({
+        content: "test content",
+        category: PostCategory.DUMMY1,
+        nickname: "testnick",
+        author: { id: userId } as User,
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestAttachment(
+    overrides?: Partial<Attachment>,
+  ): Promise<Attachment> {
+    return attachmentRepository.save(
+      attachmentRepository.create({
+        confirmed: true,
+        s3Key: `attachments/${randomUUID()}`,
+        index: null,
+        post: null,
+        ...overrides,
+      }),
+    );
+  }
 
   beforeAll(async () => {
     const { dataSource: ds, backup } = await initializePgMem(entities);
@@ -131,9 +126,9 @@ describe("PostMutationService", () => {
   describe("createPost", () => {
     it("success: 글 생성, attachment 업데이트", async () => {
       // Given: confirmed이며 associated 되지 않은 attachment 존재
-      const user = await saveTestUser(userRepository);
-      const a1 = await saveTestAttachment(attachmentRepository);
-      const a2 = await saveTestAttachment(attachmentRepository);
+      const user = await saveTestUser();
+      const a1 = await saveTestAttachment();
+      const a2 = await saveTestAttachment();
 
       // When: 글 생성 시도
       const post = await postMutationService.createPost({
@@ -157,7 +152,7 @@ describe("PostMutationService", () => {
 
     it("존재하지 않는 attachment 처리", async () => {
       // Given: 존재하지 않는 attachment인 경우
-      const user = await saveTestUser(userRepository);
+      const user = await saveTestUser();
       const nonExistentAttachmentId = 0;
 
       // When: 글 생성 시도
@@ -175,10 +170,8 @@ describe("PostMutationService", () => {
 
     it("confirmed 되지 않은 attachment 처리", async () => {
       // Given: confirmed 되지 않은 attachment인 경우
-      const user = await saveTestUser(userRepository);
-      const attachment = await saveTestAttachment(attachmentRepository, {
-        confirmed: false,
-      });
+      const user = await saveTestUser();
+      const attachment = await saveTestAttachment({ confirmed: false });
 
       // When: 글 생성 시도
       const result = postMutationService.createPost({
@@ -196,11 +189,9 @@ describe("PostMutationService", () => {
 
     it("이미 associated 된 attachment 처리", async () => {
       // Given: attachment가 이미 associated된 경우
-      const user = await saveTestUser(userRepository);
-      const existingPost = await saveTestPost(postRepository, user.id);
-      const attachment = await saveTestAttachment(attachmentRepository, {
-        post: existingPost,
-      });
+      const user = await saveTestUser();
+      const existingPost = await saveTestPost(user.id);
+      const attachment = await saveTestAttachment({ post: existingPost });
 
       // When: 글 생성 시도
       const result = postMutationService.createPost({
@@ -220,15 +211,13 @@ describe("PostMutationService", () => {
   describe("updatePost", () => {
     it("success: 글 업데이트 및 old attachment들 삭제", async () => {
       // Given: 존재하는 글 및 owner인 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const oldAttachment = await saveTestAttachment(attachmentRepository, {
-        post,
-      });
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const oldAttachment = await saveTestAttachment({ post });
       fakeS3.put(oldAttachment.s3Key);
 
       // Given: new attachments가 confirmed이며 associated 되지 않은 경우
-      const newAttachment = await saveTestAttachment(attachmentRepository);
+      const newAttachment = await saveTestAttachment();
 
       // When: 글 업데이트 시도
       await postMutationService.updatePost({
@@ -277,9 +266,9 @@ describe("PostMutationService", () => {
 
     it("글 owner가 아닌 경우 처리", async () => {
       // Given: 글이 존재하지만, owner가 일치하지 않는 경우
-      const author = await saveTestUser(userRepository);
-      const otherUser = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, author.id);
+      const author = await saveTestUser();
+      const otherUser = await saveTestUser();
+      const post = await saveTestPost(author.id);
 
       // When: 글 업데이트 시도
       const result = postMutationService.updatePost({
@@ -296,8 +285,8 @@ describe("PostMutationService", () => {
 
     it("존재하지 않는 new attachment 처리", async () => {
       // Given: 존재하는 글 및 owner인 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
 
       // Given: new attachment가 존재하지 않을 경우
       const nonExistentAttachmentId = 0;
@@ -317,13 +306,11 @@ describe("PostMutationService", () => {
 
     it("confirmed 되지 않은 새 attachment 처리", async () => {
       // Given: 존재하는 글 및 owner인 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
 
       // Given: new attachments가 confirmed가 아닌 경우
-      const attachment = await saveTestAttachment(attachmentRepository, {
-        confirmed: false,
-      });
+      const attachment = await saveTestAttachment({ confirmed: false });
 
       // When: 글 업데이트 시도
       const result = postMutationService.updatePost({
@@ -340,14 +327,12 @@ describe("PostMutationService", () => {
 
     it("이미 associated 된 새 attachment 처리", async () => {
       // Given: 존재하는 글 및 owner인 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const otherPost = await saveTestPost(postRepository, user.id);
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const otherPost = await saveTestPost(user.id);
 
       // Given: new attachments가 confirmed 되었지만, associated 된 경우
-      const attachment = await saveTestAttachment(attachmentRepository, {
-        post: otherPost,
-      });
+      const attachment = await saveTestAttachment({ post: otherPost });
 
       // When: 글 업데이트 시도
       const result = postMutationService.updatePost({
@@ -366,8 +351,8 @@ describe("PostMutationService", () => {
   describe("setPostLike", () => {
     it("success: liked false -> true, post like entity 생성", async () => {
       // Given: 글이 존재하는 경우, liked: false
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
 
       // When: liked를 true로 지정하여 요청
       await postMutationService.setPostLike(user.id, post.id, true);
@@ -386,10 +371,8 @@ describe("PostMutationService", () => {
 
     it("success: liked true -> true, post like entity 유지", async () => {
       // Given: 글이 존재하는 경우, liked: true
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id, {
-        likeCount: 1,
-      });
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id, { likeCount: 1 });
       await postLikeRepository.save(
         postLikeRepository.create({
           user: { id: user.id },
@@ -411,10 +394,8 @@ describe("PostMutationService", () => {
 
     it("success: liked true -> false, post like entity 삭제", async () => {
       // Given: 글이 존재하는 경우, liked: true
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id, {
-        likeCount: 1,
-      });
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id, { likeCount: 1 });
       await postLikeRepository.save(
         postLikeRepository.create({
           user: { id: user.id },
@@ -436,8 +417,8 @@ describe("PostMutationService", () => {
 
     it("success: liked false -> false, post like entity 없음 유지", async () => {
       // Given: 글이 존재하는 경우, liked: false
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
 
       // When: liked를 false로 지정하여 요청
       await postMutationService.setPostLike(user.id, post.id, false);
@@ -453,7 +434,7 @@ describe("PostMutationService", () => {
 
     it("존재하지 않는 글 처리", async () => {
       // Given: 글이 존재하지 않는 경우
-      const user = await saveTestUser(userRepository);
+      const user = await saveTestUser();
 
       // When: liked 요청 시도
       const result = postMutationService.setPostLike(user.id, 0, true);
@@ -466,11 +447,9 @@ describe("PostMutationService", () => {
   describe("deletePost", () => {
     it("success: 글 및 attachment 삭제", async () => {
       // Given: 글이 존재하며 owner가 일치하는 경우
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
-      const attachment = await saveTestAttachment(attachmentRepository, {
-        post,
-      });
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const attachment = await saveTestAttachment({ post });
       fakeS3.put(attachment.s3Key);
 
       // When: 글 삭제 시도
@@ -486,7 +465,7 @@ describe("PostMutationService", () => {
 
     it("존재하지 않는 글 처리", async () => {
       // Given: 글이 존재하지 않는 경우
-      const user = await saveTestUser(userRepository);
+      const user = await saveTestUser();
 
       // When: 글 삭제 시도
       const result = postMutationService.deletePost(user.id, 0);
@@ -497,9 +476,9 @@ describe("PostMutationService", () => {
 
     it("글 owner가 아닌 경우 처리", async () => {
       // Given: 글이 존재하지만, owner가 일치하지 않는 경우
-      const user = await saveTestUser(userRepository);
-      const otherUser = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, otherUser.id);
+      const user = await saveTestUser();
+      const otherUser = await saveTestUser();
+      const post = await saveTestPost(otherUser.id);
 
       // When: 글 삭제 시도
       const result = postMutationService.deletePost(user.id, post.id);

--- a/apps/backend/src/post/post-query.service.spec.ts
+++ b/apps/backend/src/post/post-query.service.spec.ts
@@ -141,7 +141,7 @@ describe("PostQueryService", () => {
         });
 
         // Then: 올바른 결과 반환
-        expect(result.entries.map((p) => p.post.id)).toEqual([ids[0], ids[1]]);
+        expect(result.items.map((p) => p.post.id)).toEqual([ids[0], ids[1]]);
         expect(result.nextCursor).toBeDefined();
 
         // When: nextCursor로 글 조회 시도
@@ -154,7 +154,7 @@ describe("PostQueryService", () => {
         });
 
         // Then: 올바른 결과 반환
-        expect(result2.entries.map((p) => p.post.id)).toEqual([ids[2], ids[4]]);
+        expect(result2.items.map((p) => p.post.id)).toEqual([ids[2], ids[4]]);
         expect(result2.nextCursor).toBeUndefined();
       });
 
@@ -179,7 +179,7 @@ describe("PostQueryService", () => {
         });
 
         // Then: 삭제된 글 다음부터 올바르게 반환
-        expect(result.entries.map((p) => p.post.id)).toEqual([ids[1], ids[2]]);
+        expect(result.items.map((p) => p.post.id)).toEqual([ids[1], ids[2]]);
       });
 
       it("category 및 orderBy와 벗어난 cursor 처리", async () => {
@@ -225,7 +225,7 @@ describe("PostQueryService", () => {
         });
 
         // Then: isOwner === true
-        expect(result.entries[0].withUser.isOwner).toBe(true);
+        expect(result.items[0].withUser.isOwner).toBe(true);
       });
 
       it("success: user가 owner 아님 -> isOwner false", async () => {
@@ -242,7 +242,7 @@ describe("PostQueryService", () => {
         });
 
         // Then: isOwner === false
-        expect(result.entries[0].withUser.isOwner).toBe(false);
+        expect(result.items[0].withUser.isOwner).toBe(false);
       });
 
       it("success: user가 like한 글 -> isLiked true", async () => {
@@ -264,7 +264,7 @@ describe("PostQueryService", () => {
         });
 
         // Then: isLiked === true
-        expect(result.entries[0].withUser.isLiked).toBe(true);
+        expect(result.items[0].withUser.isLiked).toBe(true);
       });
 
       it("success: user가 like 하지 않은 글 -> isLiked false", async () => {
@@ -280,7 +280,7 @@ describe("PostQueryService", () => {
         });
 
         // Then: isLiked === false
-        expect(result.entries[0].withUser.isLiked).toBe(false);
+        expect(result.items[0].withUser.isLiked).toBe(false);
       });
     });
 

--- a/apps/backend/src/post/post-query.service.spec.ts
+++ b/apps/backend/src/post/post-query.service.spec.ts
@@ -17,50 +17,6 @@ import { PostComment } from "src/comment/entities/post-comment.entity";
 
 const entities = [UserProfile, User, PostComment, Post, PostLike, Attachment];
 
-let userCounter = 0;
-
-async function saveTestUser(
-  repository: Repository<User>,
-  overrides?: Partial<User>,
-): Promise<User> {
-  return repository.save(
-    repository.create({
-      email: `user${++userCounter}@test.com`,
-      password: "password",
-      role: UserRole.USER,
-      ...overrides,
-    }),
-  );
-}
-
-async function saveTestPost(
-  repository: Repository<Post>,
-  userId: number,
-  overrides?: Partial<Post>,
-): Promise<Post> {
-  return repository.save(
-    repository.create({
-      content: "test content",
-      category: PostCategory.DUMMY1,
-      nickname: "testnick",
-      author: { id: userId } as User,
-      ...overrides,
-    }),
-  );
-}
-
-async function saveTestPosts(
-  repository: Repository<Post>,
-  userId: number,
-  overridesList: Partial<Post>[],
-): Promise<number[]> {
-  const ids: number[] = [];
-  for (const overrides of overridesList) {
-    ids.push((await saveTestPost(repository, userId, overrides)).id);
-  }
-  return ids;
-}
-
 describe("PostQueryService", () => {
   let module: TestingModule;
   let postQueryService: PostQueryService;
@@ -71,6 +27,45 @@ describe("PostQueryService", () => {
   let fakeS3: FakeS3StorageService;
   let dataSource: DataSource;
   let dbBackup: PGMem.IBackup;
+
+  let userCounter = 0;
+
+  async function saveTestUser(overrides?: Partial<User>): Promise<User> {
+    return userRepository.save(
+      userRepository.create({
+        email: `user${++userCounter}@test.com`,
+        password: "password",
+        role: UserRole.USER,
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestPost(
+    userId: number,
+    overrides?: Partial<Post>,
+  ): Promise<Post> {
+    return postRepository.save(
+      postRepository.create({
+        content: "test content",
+        category: PostCategory.DUMMY1,
+        nickname: "testnick",
+        author: { id: userId } as User,
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestPosts(
+    userId: number,
+    overridesList: Partial<Post>[],
+  ): Promise<number[]> {
+    const ids: number[] = [];
+    for (const overrides of overridesList) {
+      ids.push((await saveTestPost(userId, overrides)).id);
+    }
+    return ids;
+  }
 
   beforeAll(async () => {
     const { dataSource: ds, backup } = await initializePgMem(entities);
@@ -123,8 +118,8 @@ describe("PostQueryService", () => {
       // 처리합니다.
       it("success: 각 parameter 처리", async () => {
         // Given: posts
-        const user = await saveTestUser(userRepository);
-        const ids = await saveTestPosts(postRepository, user.id, [
+        const user = await saveTestUser();
+        const ids = await saveTestPosts(user.id, [
           { category: PostCategory.DUMMY1 },
           { category: PostCategory.DUMMY1 },
           { category: PostCategory.DUMMY1 },
@@ -160,8 +155,8 @@ describe("PostQueryService", () => {
 
       it("success: cursor에 해당하는 글이 삭제된 경우 올바르게 처리", async () => {
         // Given: cursor에 해당하는 글이 삭제된 경우
-        const user = await saveTestUser(userRepository);
-        const ids = await saveTestPosts(postRepository, user.id, [{}, {}, {}]);
+        const user = await saveTestUser();
+        const ids = await saveTestPosts(user.id, [{}, {}, {}]);
 
         const firstPage = await postQueryService.listPosts(user.id, {
           limit: 1,
@@ -185,8 +180,8 @@ describe("PostQueryService", () => {
       it("category 및 orderBy와 벗어난 cursor 처리", async () => {
         // Given: cursor가 category 및 orderBy를 다르게 하여 조회했을 때의
         // 결과물인 경우
-        const user = await saveTestUser(userRepository);
-        await saveTestPosts(postRepository, user.id, [
+        const user = await saveTestUser();
+        await saveTestPosts(user.id, [
           { category: PostCategory.DUMMY1 },
           { category: PostCategory.DUMMY1 },
         ]);
@@ -214,8 +209,8 @@ describe("PostQueryService", () => {
     describe("relation fields", () => {
       it("success: user가 owner -> isOwner true", async () => {
         // Given: 사용자 및 글 (테스트를 위해 단일로만 저장)
-        const user = await saveTestUser(userRepository);
-        await saveTestPost(postRepository, user.id);
+        const user = await saveTestUser();
+        await saveTestPost(user.id);
 
         // When: 글 목록 조회 시도
         const result = await postQueryService.listPosts(user.id, {
@@ -230,9 +225,9 @@ describe("PostQueryService", () => {
 
       it("success: user가 owner 아님 -> isOwner false", async () => {
         // Given: 글 작성자와 다른 사용자
-        const author = await saveTestUser(userRepository);
-        const viewer = await saveTestUser(userRepository);
-        await saveTestPost(postRepository, author.id);
+        const author = await saveTestUser();
+        const viewer = await saveTestUser();
+        await saveTestPost(author.id);
 
         // When: viewer로 글 목록 조회 시도
         const result = await postQueryService.listPosts(viewer.id, {
@@ -247,8 +242,8 @@ describe("PostQueryService", () => {
 
       it("success: user가 like한 글 -> isLiked true", async () => {
         // Given: user가 like한 글
-        const user = await saveTestUser(userRepository);
-        const post = await saveTestPost(postRepository, user.id);
+        const user = await saveTestUser();
+        const post = await saveTestPost(user.id);
         await postLikeRepository.save(
           postLikeRepository.create({
             user: { id: user.id },
@@ -269,8 +264,8 @@ describe("PostQueryService", () => {
 
       it("success: user가 like 하지 않은 글 -> isLiked false", async () => {
         // Given: user가 like하지 않은 글
-        const user = await saveTestUser(userRepository);
-        await saveTestPost(postRepository, user.id);
+        const user = await saveTestUser();
+        await saveTestPost(user.id);
 
         // When: 글 목록 조회 시도
         const result = await postQueryService.listPosts(user.id, {
@@ -286,8 +281,8 @@ describe("PostQueryService", () => {
 
     it("success: 올바른 attachments URL 맵 반환", async () => {
       // Given: attachment가 있는 글
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
       const attachment = await attachmentRepository.save(
         attachmentRepository.create({
           confirmed: true,
@@ -314,7 +309,7 @@ describe("PostQueryService", () => {
   describe("getPost", () => {
     it("success: 올바른 fields 반환", async () => {
       // Given: 글이 존재하는 경우
-      const user = await saveTestUser(userRepository);
+      const user = await saveTestUser();
       const post = await postRepository.save(
         postRepository.create({
           content: "hello world",
@@ -338,8 +333,8 @@ describe("PostQueryService", () => {
     describe("relation fields", () => {
       it("success: user가 owner -> isOwner true", async () => {
         // Given: 글 작성자
-        const user = await saveTestUser(userRepository);
-        const post = await saveTestPost(postRepository, user.id);
+        const user = await saveTestUser();
+        const post = await saveTestPost(user.id);
 
         // When: 글 조회 시도
         const result = await postQueryService.getPost(user.id, post.id);
@@ -350,9 +345,9 @@ describe("PostQueryService", () => {
 
       it("success: user가 owner 아님 -> isOwner false", async () => {
         // Given: 글 작성자와 다른 사용자
-        const author = await saveTestUser(userRepository);
-        const viewer = await saveTestUser(userRepository);
-        const post = await saveTestPost(postRepository, author.id);
+        const author = await saveTestUser();
+        const viewer = await saveTestUser();
+        const post = await saveTestPost(author.id);
 
         // When: viewer로 글 조회 시도
         const result = await postQueryService.getPost(viewer.id, post.id);
@@ -363,8 +358,8 @@ describe("PostQueryService", () => {
 
       it("success: user가 like한 글 -> isLiked true", async () => {
         // Given: user가 like한 글
-        const user = await saveTestUser(userRepository);
-        const post = await saveTestPost(postRepository, user.id);
+        const user = await saveTestUser();
+        const post = await saveTestPost(user.id);
         await postLikeRepository.save(
           postLikeRepository.create({
             user: { id: user.id },
@@ -381,8 +376,8 @@ describe("PostQueryService", () => {
 
       it("success: user가 like 하지 않은 글 -> isLiked false", async () => {
         // Given: user가 like하지 않은 글
-        const user = await saveTestUser(userRepository);
-        const post = await saveTestPost(postRepository, user.id);
+        const user = await saveTestUser();
+        const post = await saveTestPost(user.id);
 
         // When: 글 조회 시도
         const result = await postQueryService.getPost(user.id, post.id);
@@ -394,8 +389,8 @@ describe("PostQueryService", () => {
 
     it("success: 올바른 attachments URL 맵 반환", async () => {
       // Given: attachment가 있는 글
-      const user = await saveTestUser(userRepository);
-      const post = await saveTestPost(postRepository, user.id);
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
       const attachment = await attachmentRepository.save(
         attachmentRepository.create({
           confirmed: true,
@@ -416,7 +411,7 @@ describe("PostQueryService", () => {
 
     it("존재하지 않는 글 처리", async () => {
       // Given: 글이 존재하지 않는 경우
-      const user = await saveTestUser(userRepository);
+      const user = await saveTestUser();
       const nonExistentId = 0;
 
       // When: 글 조회 시도

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -7,6 +7,10 @@ import { Attachment } from "../attachment/entities/attachment.entity";
 import { S3StorageService } from "src/s3-storage/s3-storage.service";
 import { PostNotFoundError } from "./post.errors";
 import { InvalidCursorError } from "src/common/errors/pagination.errors";
+import {
+  CursorPaginationOptions,
+  CursorPaginationResult,
+} from "src/common/types/pagination";
 
 /* shared types */
 
@@ -20,21 +24,16 @@ export type PostWithRelations = {
 
 export type AttachmentToUrlMap = Record<number, string>;
 
-export type ListPostsOrderBy = "createdAt";
-
 /* listPosts */
 
-export type ListPostsPaginationOptions = {
-  cursor?: string;
-  limit: number;
-  category?: PostCategory;
-  orderBy: ListPostsOrderBy;
-  orderDirection: "asc" | "desc";
-};
+export type ListPostsOrderBy = "createdAt";
 
-export type ListPostsResult = {
-  entries: PostWithRelations[];
-  nextCursor?: string;
+export type ListPostsPaginationOptions =
+  CursorPaginationOptions<ListPostsOrderBy> & {
+    category?: PostCategory;
+  };
+
+export type ListPostsResult = CursorPaginationResult<PostWithRelations> & {
   attachmentToUrl: AttachmentToUrlMap;
 };
 
@@ -175,7 +174,7 @@ export class PostQueryService {
     const resultPosts = posts.slice(0, limit);
     const lastPost = resultPosts.at(-1);
     return {
-      entries: resultPosts.map((post) => ({
+      items: resultPosts.map((post) => ({
         post,
         withUser: {
           isOwner: post.authorId === userId,

--- a/apps/backend/src/post/post.controller.ts
+++ b/apps/backend/src/post/post.controller.ts
@@ -93,16 +93,19 @@ export class PostController {
     @CurrentUser() user: User,
     @ZodQuery(ListPostsQueryDtoSchema) query: ListPostsQueryDto,
   ): Promise<ListPostsSuccessResponseDto> {
-    const { entries, nextCursor, attachmentToUrl } =
-      await this.postQueryService.listPosts(user.id, {
-        cursor: query.cursor,
-        limit: query.limit,
-        category: query.category
-          ? apiToEntityCategory[query.category]
-          : undefined,
-        orderBy: query.orderBy,
-        orderDirection: query.orderDirection,
-      });
+    const {
+      items: entries,
+      nextCursor,
+      attachmentToUrl,
+    } = await this.postQueryService.listPosts(user.id, {
+      cursor: query.cursor,
+      limit: query.limit,
+      category: query.category
+        ? apiToEntityCategory[query.category]
+        : undefined,
+      orderBy: query.orderBy,
+      orderDirection: query.orderDirection,
+    });
 
     return {
       success: true,

--- a/apps/backend/src/resource/resource-mutation.service.spec.ts
+++ b/apps/backend/src/resource/resource-mutation.service.spec.ts
@@ -13,27 +13,26 @@ import { initializePgMem } from "src/test/pg-mem.helper";
 
 const entities = [Resource];
 
-async function saveTestResource(
-  repository: Repository<Resource>,
-  overrides?: Partial<Resource>,
-): Promise<Resource> {
-  return repository.save(
-    repository.create({
-      title: "test resource",
-      type: ResourceType.ARTICLE,
-      category: ResourceCategory.DUMMY1,
-      url: "https://example.com",
-      ...overrides,
-    }),
-  );
-}
-
 describe("ResourceMutationService", () => {
   let module: TestingModule;
   let resourceMutationService: ResourceMutationService;
   let resourceRepository: Repository<Resource>;
   let dataSource: DataSource;
   let dbBackup: PGMem.IBackup;
+
+  async function saveTestResource(
+    overrides?: Partial<Resource>,
+  ): Promise<Resource> {
+    return resourceRepository.save(
+      resourceRepository.create({
+        title: "test resource",
+        type: ResourceType.ARTICLE,
+        category: ResourceCategory.DUMMY1,
+        url: "https://example.com",
+        ...overrides,
+      }),
+    );
+  }
 
   beforeAll(async () => {
     const { dataSource: ds, backup } = await initializePgMem(entities);
@@ -88,7 +87,7 @@ describe("ResourceMutationService", () => {
   describe("updateResource", () => {
     it("success: 콘텐츠 업데이트", async () => {
       // Given: 콘텐츠가 존재하는 경우
-      const resource = await saveTestResource(resourceRepository);
+      const resource = await saveTestResource();
 
       // When: 콘텐츠 업데이트 시도
       await resourceMutationService.updateResource({
@@ -130,7 +129,7 @@ describe("ResourceMutationService", () => {
   describe("deleteResource", () => {
     it("success: 콘텐츠 삭제", async () => {
       // Given: 콘텐츠가 존재하는 경우
-      const resource = await saveTestResource(resourceRepository);
+      const resource = await saveTestResource();
 
       // When: 콘텐츠 삭제 시도
       await resourceMutationService.deleteResource(resource.id);

--- a/apps/backend/src/resource/resource-query.service.spec.ts
+++ b/apps/backend/src/resource/resource-query.service.spec.ts
@@ -13,38 +13,36 @@ import { initializePgMem } from "src/test/pg-mem.helper";
 
 const entities = [Resource];
 
-async function saveTestResource(
-  repository: Repository<Resource>,
-  overrides?: Partial<Resource>,
-): Promise<Resource> {
-  return repository.save(
-    repository.create({
-      title: "test resource",
-      type: ResourceType.ARTICLE,
-      category: ResourceCategory.DUMMY1,
-      url: "https://example.com",
-      ...overrides,
-    }),
-  );
-}
-
-async function saveTestResources(
-  repository: Repository<Resource>,
-  overridesList: Partial<Resource>[],
-): Promise<number[]> {
-  const ids: number[] = [];
-  for (const overrides of overridesList) {
-    ids.push((await saveTestResource(repository, overrides)).id);
-  }
-  return ids;
-}
-
 describe("ResourceQueryService", () => {
   let module: TestingModule;
   let resourceQueryService: ResourceQueryService;
   let resourceRepository: Repository<Resource>;
   let dataSource: DataSource;
   let dbBackup: PGMem.IBackup;
+
+  async function saveTestResource(
+    overrides?: Partial<Resource>,
+  ): Promise<Resource> {
+    return resourceRepository.save(
+      resourceRepository.create({
+        title: "test resource",
+        type: ResourceType.ARTICLE,
+        category: ResourceCategory.DUMMY1,
+        url: "https://example.com",
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestResources(
+    overridesList: Partial<Resource>[],
+  ): Promise<number[]> {
+    const ids: number[] = [];
+    for (const overrides of overridesList) {
+      ids.push((await saveTestResource(overrides)).id);
+    }
+    return ids;
+  }
 
   beforeAll(async () => {
     const { dataSource: ds, backup } = await initializePgMem(entities);
@@ -78,7 +76,7 @@ describe("ResourceQueryService", () => {
   describe("listResourcesWithOffset", () => {
     it("success: 각 parameter 처리", async () => {
       // Given: resources
-      const ids = await saveTestResources(resourceRepository, [
+      const ids = await saveTestResources([
         { category: ResourceCategory.DUMMY1 },
         { category: ResourceCategory.DUMMY2 },
         { category: ResourceCategory.DUMMY1 },
@@ -117,7 +115,7 @@ describe("ResourceQueryService", () => {
   describe("listResourcesWithCursor", () => {
     it("success: 각 parameter 처리", async () => {
       // Given: resources
-      const ids = await saveTestResources(resourceRepository, [
+      const ids = await saveTestResources([
         { category: ResourceCategory.DUMMY1 },
         { category: ResourceCategory.DUMMY2 },
         { category: ResourceCategory.DUMMY1 },
@@ -152,7 +150,7 @@ describe("ResourceQueryService", () => {
 
     it("success: cursor에 해당하는 resource가 삭제된 경우 올바르게 처리", async () => {
       // Given: cursor에 해당하는 resource가 삭제된 경우
-      const ids = await saveTestResources(resourceRepository, [{}, {}, {}]);
+      const ids = await saveTestResources([{}, {}, {}]);
 
       const firstPage = await resourceQueryService.listResourcesWithCursor({
         limit: 1,
@@ -176,7 +174,7 @@ describe("ResourceQueryService", () => {
     it("category 및 orderBy와 벗어난 cursor 처리", async () => {
       // Given: cursor가 category 및 orderBy를 다르게 하여 조회했을 때의
       // 결과물인 경우
-      await saveTestResources(resourceRepository, [
+      await saveTestResources([
         { category: ResourceCategory.DUMMY1 },
         { category: ResourceCategory.DUMMY1 },
       ]);

--- a/apps/backend/src/resource/resource-query.service.ts
+++ b/apps/backend/src/resource/resource-query.service.ts
@@ -3,34 +3,28 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Resource, ResourceCategory } from "./entities/resource.entity";
 import { InvalidCursorError } from "src/common/errors/pagination.errors";
+import {
+  CursorPaginationOptions,
+  CursorPaginationResult,
+  OffsetPaginationOptions,
+  OffsetPaginationResult,
+} from "src/common/types/pagination";
 
 export type ListResourcesOrderBy = "createdAt";
 
-export type ListResourcesWithOffsetOptions = {
-  offset: number;
-  limit: number;
-  category?: ResourceCategory;
-  orderBy: ListResourcesOrderBy;
-  orderDirection: "asc" | "desc";
-};
+export type ListResourcesWithOffsetOptions =
+  OffsetPaginationOptions<ListResourcesOrderBy> & {
+    category?: ResourceCategory;
+  };
 
-export type ListResourcesWithOffsetResult = {
-  items: Resource[];
-  hasNext: boolean;
-};
+export type ListResourcesWithOffsetResult = OffsetPaginationResult<Resource>;
 
-export type ListResourcesWithCursorOptions = {
-  cursor?: string;
-  limit: number;
-  category?: ResourceCategory;
-  orderBy: ListResourcesOrderBy;
-  orderDirection: "asc" | "desc";
-};
+export type ListResourcesWithCursorOptions =
+  CursorPaginationOptions<ListResourcesOrderBy> & {
+    category?: ResourceCategory;
+  };
 
-export type ListResourcesWithCursorResult = {
-  items: Resource[];
-  nextCursor?: string;
-};
+export type ListResourcesWithCursorResult = CursorPaginationResult<Resource>;
 
 type CursorPayload = {
   category: ResourceCategory | null;


### PR DESCRIPTION
## 요약

- 가독성, 일관성, 확장성을 고려하여 백엔드의 service 및 테스트 코드를 리팩토링하였습니다.

## 내용 (`backend`)

### Pagination method들의 parameter 및 return type 분리

- offset 및 cursor-based pagination을 위한 parameter와 return type이 중복되기에, 이를 common type으로 분리하였습니다.
- 해당 common type들은 이후 pagination을 지원해야 하는 service에서 사용 가능합니다.

### `AuthService` entity helper 형식 변경

- 기존 코드에서는 다른 테스트 코드에서 사용하는 `saveTestX(...)` 패턴과 일치하지 않는 `createTestUser(...)`를 사용하고 있었습니다.
- 일관성을 위해 `saveTestUser(...)` 방식으로 리팩토링 하였습니다.

### `MissionParticipationService` entity helper 형식 변경

- `saveTestUser(...)`와 `saveTestUserProfile(...)`의 분리된 사용이 코드의 가독성을 해친다고 판단되어 이를 통합하였습니다.

### 모든 테스트 코드의 entity helper에서 repository parameter 받지 않도록 변경

- 기존 코드에서는 모든 entity helper에서 repository를 parameter로 받고 있었습니다.
- 그러나 해당 파라미터를 매번 넘기는 것은 코드의 가독성을 해친다고 판단하였습니다.
- 따라서 repository 파라미터를 받지 않도록 변경하였고, 이를 위해 entity helper의 위치를 describe() block 안으로 이동했습니다.
  - 해당 위치 변경이 현재는 큰 문제를 일으키지 않을 것이라고 생각하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced shared pagination type definitions supporting cursor-based and offset-based pagination strategies.

* **Refactor**
  * Unified pagination response structures across services using standardized type definitions.
  * Refactored test helper functions to improve test suite maintainability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->