### PR TITLE
백엔드 자가진단 기능 구현

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -30,6 +30,8 @@ import { Resource } from "./resource/entities/resource.entity";
 import { MissionModule } from "./mission/mission.module";
 import { Mission } from "./mission/entities/mission.entity";
 import { MissionAssignment } from "./mission/entities/mission-assignment.entity";
+import { DiagnosisModule } from "./diagnosis/diagnosis.module";
+import { DiagnosisEntry } from "./diagnosis/entities/diagnosis-entry.entity";
 
 @Module({
   imports: [
@@ -58,6 +60,7 @@ import { MissionAssignment } from "./mission/entities/mission-assignment.entity"
           Resource,
           Mission,
           MissionAssignment,
+          DiagnosisEntry,
         ],
         synchronize: process.env.NODE_ENV !== "production",
       }),
@@ -72,6 +75,7 @@ import { MissionAssignment } from "./mission/entities/mission-assignment.entity"
     CommentModule,
     ResourceModule,
     MissionModule,
+    DiagnosisModule,
   ],
   // 2026-03-18: AuthGuard -- UserService circular dependency 문제를 해결하기
   // 위해 다음과 같이 배치하였습니다.

--- a/apps/backend/src/diagnosis/diagnosis.controller.ts
+++ b/apps/backend/src/diagnosis/diagnosis.controller.ts
@@ -1,0 +1,38 @@
+import type {
+  CreateDiagnosisRequestDto,
+  CreateDiagnosisSuccessResponseDto,
+} from "@mindseed/api-types";
+import {
+  CreateDiagnosisRequestDtoSchema,
+  CreateDiagnosisResponseDtoSchema,
+} from "@mindseed/api-types";
+import { Controller, HttpCode, HttpStatus, Post } from "@nestjs/common";
+import { CurrentUser, UserOnly } from "src/auth/decorators/auth.decorators";
+import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
+import { ZodBody } from "src/common/pipes/zod-validation.decorator";
+import { User } from "src/user/entities/user.entity";
+import { DiagnosisService } from "./diagnosis.service";
+
+@Controller("/diagnoses")
+export class DiagnosisController {
+  constructor(private readonly diagnosisService: DiagnosisService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UserOnly()
+  @ZodEncodeResponse(CreateDiagnosisResponseDtoSchema)
+  async createDiagnosis(
+    @CurrentUser() user: User,
+    @ZodBody(CreateDiagnosisRequestDtoSchema)
+    body: CreateDiagnosisRequestDto,
+  ): Promise<CreateDiagnosisSuccessResponseDto> {
+    await this.diagnosisService.createDiagnosisEntry({
+      userId: user.id,
+      depressionScore: body.depressionScore,
+      anxietyScore: body.anxietyScore,
+      stressScore: body.stressScore,
+    });
+
+    return { success: true, data: null };
+  }
+}

--- a/apps/backend/src/diagnosis/diagnosis.module.ts
+++ b/apps/backend/src/diagnosis/diagnosis.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { AuthModule } from "src/auth/auth.module";
+import { DiagnosisEntry } from "./entities/diagnosis-entry.entity";
+import { DiagnosisService } from "./diagnosis.service";
+import { DiagnosisController } from "./diagnosis.controller";
+import { UserModule } from "src/user/user.module";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DiagnosisEntry]), AuthModule, UserModule],
+  controllers: [DiagnosisController],
+  providers: [DiagnosisService],
+})
+export class DiagnosisModule {}

--- a/apps/backend/src/diagnosis/diagnosis.service.spec.ts
+++ b/apps/backend/src/diagnosis/diagnosis.service.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { DataSource, Repository } from "typeorm";
+import PGMem from "pg-mem";
+import { DiagnosisService } from "./diagnosis.service";
+import { DiagnosisEntry } from "./entities/diagnosis-entry.entity";
+import { User, UserRole } from "src/user/entities/user.entity";
+import { UserProfile } from "src/user/entities/user-profile.entity";
+import { initializePgMem } from "src/test/pg-mem.helper";
+
+const entities = [User, UserProfile, DiagnosisEntry];
+
+describe("DiagnosisService", () => {
+  let module: TestingModule;
+  let diagnosisService: DiagnosisService;
+  let diagnosisEntryRepository: Repository<DiagnosisEntry>;
+  let userRepository: Repository<User>;
+  let dataSource: DataSource;
+  let dbBackup: PGMem.IBackup;
+
+  async function saveTestUser(overrides?: Partial<User>): Promise<User> {
+    return userRepository.save(
+      userRepository.create({
+        email: "test@example.com",
+        password: "hashed",
+        role: UserRole.USER,
+        ...overrides,
+      }),
+    );
+  }
+
+  beforeAll(async () => {
+    const { dataSource: ds, backup } = await initializePgMem(entities);
+    dataSource = ds;
+    dbBackup = backup;
+
+    module = await Test.createTestingModule({
+      providers: [
+        DiagnosisService,
+        {
+          provide: getRepositoryToken(DiagnosisEntry),
+          useValue: dataSource.getRepository(DiagnosisEntry),
+        },
+      ],
+    }).compile();
+
+    diagnosisService = module.get(DiagnosisService);
+    diagnosisEntryRepository = dataSource.getRepository(DiagnosisEntry);
+    userRepository = dataSource.getRepository(User);
+  });
+
+  beforeEach(() => {
+    dbBackup.restore();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+    await module.close();
+  });
+
+  describe("createDiagnosisEntry", () => {
+    it("success: 진단 결과 저장", async () => {
+      // Given
+      const user = await saveTestUser();
+
+      // When: 진단 결과 저장 시도
+      const entry = await diagnosisService.createDiagnosisEntry({
+        userId: user.id,
+        depressionScore: 10,
+        anxietyScore: 8,
+        stressScore: 12,
+      });
+
+      // Then: 진단 결과 저장
+      const saved = await diagnosisEntryRepository.findOneBy({ id: entry.id });
+      expect(saved).toMatchObject({
+        userId: user.id,
+        depressionScore: 10,
+        anxietyScore: 8,
+        stressScore: 12,
+      });
+    });
+  });
+});

--- a/apps/backend/src/diagnosis/diagnosis.service.ts
+++ b/apps/backend/src/diagnosis/diagnosis.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { DiagnosisEntry } from "./entities/diagnosis-entry.entity";
+
+export type CreateDiagnosisEntryOptions = {
+  userId: number;
+  depressionScore: number;
+  anxietyScore: number;
+  stressScore: number;
+};
+
+@Injectable()
+export class DiagnosisService {
+  constructor(
+    @InjectRepository(DiagnosisEntry)
+    private readonly diagnosisEntryRepository: Repository<DiagnosisEntry>,
+  ) {}
+
+  async createDiagnosisEntry(
+    options: CreateDiagnosisEntryOptions,
+  ): Promise<DiagnosisEntry> {
+    const diagnosisEntry = await this.diagnosisEntryRepository.save(
+      this.diagnosisEntryRepository.create({
+        userId: options.userId,
+        depressionScore: options.depressionScore,
+        anxietyScore: options.anxietyScore,
+        stressScore: options.stressScore,
+      }),
+    );
+    return diagnosisEntry;
+  }
+}

--- a/apps/backend/src/diagnosis/entities/diagnosis-entry.entity.ts
+++ b/apps/backend/src/diagnosis/entities/diagnosis-entry.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import { User } from "src/user/entities/user.entity";
+
+@Entity({ name: "diagnosis_entry" })
+export class DiagnosisEntry {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: "user_id" })
+  user: User;
+
+  @Column({ name: "user_id" })
+  userId: number;
+
+  @Column({ name: "depression_score" })
+  depressionScore: number;
+
+  @Column({ name: "anxiety_score" })
+  anxietyScore: number;
+
+  @Column({ name: "stress_score" })
+  stressScore: number;
+
+  @CreateDateColumn({ type: "timestamptz", name: "created_at" })
+  createdAt: Date;
+}

--- a/apps/backend/src/diagnosis/entities/diagnosis-entry.entity.ts
+++ b/apps/backend/src/diagnosis/entities/diagnosis-entry.entity.ts
@@ -13,7 +13,7 @@ export class DiagnosisEntry {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
   @JoinColumn({ name: "user_id" })
   user: User;
 

--- a/packages/api-types/src/diagnoses/create-diagnosis.ts
+++ b/packages/api-types/src/diagnoses/create-diagnosis.ts
@@ -1,0 +1,30 @@
+/*
+ POST /diagnoses
+ Auth: USER role
+*/
+
+import z from "zod";
+import { responseDtoSchema } from "src/helpers";
+
+export const CreateDiagnosisRequestDtoSchema = z.object({
+  depressionScore: z.int().min(0).max(100),
+  anxietyScore: z.int().min(0).max(100),
+  stressScore: z.int().min(0).max(100),
+});
+
+export type CreateDiagnosisRequestDto = z.output<
+  typeof CreateDiagnosisRequestDtoSchema
+>;
+
+export const CreateDiagnosisResponseDtoSchema = responseDtoSchema(
+  z.null(),
+  z.never(),
+);
+
+export type CreateDiagnosisResponseDto = z.output<
+  typeof CreateDiagnosisResponseDtoSchema
+>;
+export type CreateDiagnosisSuccessResponseDto = Extract<
+  CreateDiagnosisResponseDto,
+  { success: true }
+>;

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -41,6 +41,8 @@ export * from "./missions/admin/create-mission";
 export * from "./missions/admin/update-mission";
 export * from "./missions/admin/delete-mission";
 
+export * from "./diagnoses/create-diagnosis";
+
 export * from "./resources/list-resources";
 export * from "./resources/admin/list-resources";
 export * from "./resources/admin/create-resource";


### PR DESCRIPTION
## 요약

- Closes #104 
- 백엔드 측에서 자가진단 기능에 요구되는 부분을 구현하였습니다.

## 내용

- `api-types`: `/diagnoses` endpoint를 작성하였습니다.
- `backend`: `DiagnosisEntry`, `DiagnosisService`, `DiagnosisController`를 작성하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authenticated users can submit mental-health assessment scores (depression, anxiety, stress) via a new secure endpoint; inputs are validated as integers between 0–100 and a successful submission returns 201.
  * Submitted assessments are persisted and timestamped for later retrieval/analysis.

* **Tests**
  * Added automated tests covering creation and persistence of diagnosis entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->