### PR TITLE
백엔드 미션 제공 구현

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -29,6 +29,7 @@
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^6.0.0",
+    "cron": "^4.4.0",
     "ioredis": "^5.10.0",
     "ioredis-mock": "^8.13.1",
     "nodemailer": "^8.0.3",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -37,6 +37,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.28",
+    "typeorm-naming-strategies": "^4.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import {
   mailConfig,
   redisConfig,
   s3Config,
+  timeZoneConfig,
 } from "./config";
 import { DatabaseModule } from "./database/database.module";
 import { RedisModule } from "./redis/redis.module";
@@ -26,7 +27,14 @@ import { DiagnosisModule } from "./diagnosis/diagnosis.module";
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [databaseConfig, redisConfig, jwtConfig, mailConfig, s3Config],
+      load: [
+        databaseConfig,
+        redisConfig,
+        jwtConfig,
+        mailConfig,
+        s3Config,
+        timeZoneConfig,
+      ],
     }),
     ScheduleModule.forRoot(),
     DatabaseModule,

--- a/apps/backend/src/attachment/entities/attachment.entity.ts
+++ b/apps/backend/src/attachment/entities/attachment.entity.ts
@@ -15,19 +15,19 @@ export class Attachment {
   @Column({ default: false })
   confirmed: boolean;
 
-  @Column({ name: "s3_key" })
+  @Column()
   s3Key: string;
 
   @Column({ type: "int", nullable: true })
   index: number | null;
 
-  @Column({ name: "post_id", nullable: true })
+  @Column({ nullable: true })
   postId: number | null;
 
   @ManyToOne(() => Post, (post) => post.attachments, {
     nullable: true,
     onDelete: "CASCADE",
   })
-  @JoinColumn({ name: "post_id" })
+  @JoinColumn()
   post: Post | null;
 }

--- a/apps/backend/src/auth/refresh-token/refresh-token.entity.ts
+++ b/apps/backend/src/auth/refresh-token/refresh-token.entity.ts
@@ -17,13 +17,13 @@ export class RefreshToken {
   @Column()
   token: string;
 
-  @TimestampColumn({ name: "expires_at" })
+  @TimestampColumn()
   expiresAt: Temporal.Instant;
 
-  @Column({ name: "user_id" })
+  @Column()
   userId: number;
 
   @ManyToOne(() => User, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "user_id" })
+  @JoinColumn()
   user: User;
 }

--- a/apps/backend/src/comment/entities/post-comment.entity.ts
+++ b/apps/backend/src/comment/entities/post-comment.entity.ts
@@ -30,30 +30,27 @@ export class PostComment {
   @Column({ type: "text" })
   content: string;
 
-  @Column({ name: "post_id" })
+  @Column()
   postId: number;
 
   @ManyToOne(() => Post, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "post_id" })
+  @JoinColumn()
   post: Post;
 
-  @Column({ name: "author_id" })
+  @Column()
   authorId: number;
 
   @ManyToOne(() => User)
-  @JoinColumn({ name: "author_id" })
+  @JoinColumn()
   author: User;
 
-  @CreateTimestampColumn({ name: "created_at" })
+  @CreateTimestampColumn()
   createdAt: Temporal.Instant;
 
-  @UpdateTimestampColumn({ name: "updated_at" })
+  @UpdateTimestampColumn()
   updatedAt: Temporal.Instant;
 
-  @TimestampColumn({
-    name: "deleted_at",
-    nullable: true,
-  })
+  @TimestampColumn({ nullable: true })
   deletedAt: Temporal.Instant | null;
 
   @Column({ name: "deleted_by", nullable: true })
@@ -66,7 +63,6 @@ export class PostComment {
   @Column({
     type: "enum",
     enum: DeletionType,
-    name: "deletion_type",
     nullable: true,
   })
   deletionType: DeletionType | null;

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -34,3 +34,7 @@ export const mailConfig = registerAs("mail", () => ({
   from: process.env.MAIL_FROM,
   driver: process.env.MAIL_DRIVER,
 }));
+
+export const timeZoneConfig = registerAs("timeZone", () => ({
+  timeZone: process.env.TIME_ZONE!,
+}));

--- a/apps/backend/src/database/database.module.ts
+++ b/apps/backend/src/database/database.module.ts
@@ -13,6 +13,7 @@ import { Resource } from "src/resource/entities/resource.entity";
 import { Mission } from "src/mission/entities/mission.entity";
 import { MissionAssignment } from "src/mission/entities/mission-assignment.entity";
 import { DiagnosisEntry } from "src/diagnosis/entities/diagnosis-entry.entity";
+import { SnakeNamingStrategy } from "typeorm-naming-strategies";
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { DiagnosisEntry } from "src/diagnosis/entities/diagnosis-entry.entity";
           DiagnosisEntry,
         ],
         synchronize: process.env.NODE_ENV !== "production",
+        namingStrategy: new SnakeNamingStrategy(),
       }),
     }),
   ],

--- a/apps/backend/src/diagnosis/entities/diagnosis-entry.entity.ts
+++ b/apps/backend/src/diagnosis/entities/diagnosis-entry.entity.ts
@@ -15,21 +15,21 @@ export class DiagnosisEntry {
   id: number;
 
   @ManyToOne(() => User, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "user_id" })
+  @JoinColumn()
   user: User;
 
-  @Column({ name: "user_id" })
+  @Column()
   userId: number;
 
-  @Column({ name: "depression_score" })
+  @Column()
   depressionScore: number;
 
-  @Column({ name: "anxiety_score" })
+  @Column()
   anxietyScore: number;
 
-  @Column({ name: "stress_score" })
+  @Column()
   stressScore: number;
 
-  @CreateTimestampColumn({ name: "created_at" })
+  @CreateTimestampColumn()
   createdAt: Temporal.Instant;
 }

--- a/apps/backend/src/mission/entities/mission-assignment.entity.ts
+++ b/apps/backend/src/mission/entities/mission-assignment.entity.ts
@@ -20,24 +20,24 @@ export class MissionAssignment {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ name: "user_id" })
+  @Column()
   userId: number;
 
   @ManyToOne(() => User, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "user_id" })
+  @JoinColumn()
   user: User;
 
-  @Column({ name: "mission_id" })
+  @Column()
   missionId: number;
 
   @ManyToOne(() => Mission, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "mission_id" })
+  @JoinColumn()
   mission: Mission;
 
-  @TimestampColumn({ name: "available_from" })
+  @TimestampColumn()
   availableFrom: Temporal.Instant;
 
-  @TimestampColumn({ name: "available_until" })
+  @TimestampColumn()
   availableUntil: Temporal.Instant;
 
   @Column({
@@ -47,6 +47,6 @@ export class MissionAssignment {
   })
   status: MissionAssignmentStatus;
 
-  @TimestampColumn({ name: "completed_at", nullable: true })
+  @TimestampColumn({ nullable: true })
   completedAt: Temporal.Instant | null;
 }

--- a/apps/backend/src/mission/entities/mission.entity.ts
+++ b/apps/backend/src/mission/entities/mission.entity.ts
@@ -22,7 +22,7 @@ export class Mission {
   @Column()
   description: string;
 
-  @Column({ name: "min_level" })
+  @Column()
   minLevel: number;
 
   @Column({ type: "enum", enum: TestCategory })
@@ -31,9 +31,9 @@ export class Mission {
   @Column()
   points: number;
 
-  @CreateTimestampColumn({ name: "created_at" })
+  @CreateTimestampColumn()
   createdAt: Temporal.Instant;
 
-  @UpdateTimestampColumn({ name: "updated_at" })
+  @UpdateTimestampColumn()
   updatedAt: Temporal.Instant;
 }

--- a/apps/backend/src/mission/mission-generation/mission-generation.cron.ts
+++ b/apps/backend/src/mission/mission-generation/mission-generation.cron.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable, OnModuleInit } from "@nestjs/common";
+import { CronExpression, SchedulerRegistry } from "@nestjs/schedule";
+import type { ConfigType } from "@nestjs/config";
+import { CronJob } from "cron";
+import { MissionGenerationJob } from "./mission-generation.job";
+import { timeZoneConfig } from "src/config";
+
+@Injectable()
+export class MissionGenerationCron implements OnModuleInit {
+  constructor(
+    @Inject(timeZoneConfig.KEY)
+    private readonly timeZoneCfg: ConfigType<typeof timeZoneConfig>,
+    private readonly missionGenerationJob: MissionGenerationJob,
+    private readonly schedulerRegistry: SchedulerRegistry,
+  ) {}
+
+  onModuleInit() {
+    const job = new CronJob(
+      CronExpression.EVERY_DAY_AT_MIDNIGHT,
+      () => this.handleCron(),
+      null,
+      true,
+      this.timeZoneCfg.timeZone,
+    );
+
+    this.schedulerRegistry.addCronJob("mission-generation", job);
+  }
+
+  private async handleCron(): Promise<void> {
+    await this.missionGenerationJob.assignMissionsToUsers();
+  }
+}

--- a/apps/backend/src/mission/mission-generation/mission-generation.job.ts
+++ b/apps/backend/src/mission/mission-generation/mission-generation.job.ts
@@ -1,4 +1,4 @@
-import { User } from "src/user/entities/user.entity";
+import { User, UserRole } from "src/user/entities/user.entity";
 import { MissionGenerationService } from "./mission-generation.service";
 import { Repository } from "typeorm";
 import { Inject, Injectable } from "@nestjs/common";
@@ -32,7 +32,10 @@ export class MissionGenerationJob {
 
   async assignMissionsToUsers(): Promise<void> {
     const nowZdt = Temporal.Now.zonedDateTimeISO(this.timeZoneCfg.timeZone);
-    const users = await this.userRepository.find({ select: { id: true } });
+    const users = await this.userRepository.find({
+      select: { id: true },
+      where: { role: UserRole.USER },
+    });
     const chunks = chunk(users, USER_CHUNK_SIZE);
 
     for (const chunk of chunks) {

--- a/apps/backend/src/mission/mission-generation/mission-generation.job.ts
+++ b/apps/backend/src/mission/mission-generation/mission-generation.job.ts
@@ -1,0 +1,46 @@
+import { User } from "src/user/entities/user.entity";
+import { MissionGenerationService } from "./mission-generation.service";
+import { Repository } from "typeorm";
+import { Inject, Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Temporal } from "@js-temporal/polyfill";
+import { timeZoneConfig } from "src/config";
+import type { ConfigType } from "@nestjs/config";
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}
+
+const USER_CHUNK_SIZE = 50;
+
+/**
+ * mission assignment의 batch processing을 담당한다.
+ */
+@Injectable()
+export class MissionGenerationJob {
+  constructor(
+    @Inject(timeZoneConfig.KEY)
+    private readonly timeZoneCfg: ConfigType<typeof timeZoneConfig>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly missionGenerationService: MissionGenerationService,
+  ) {}
+
+  async assignMissionsToUsers(): Promise<void> {
+    const nowZdt = Temporal.Now.zonedDateTimeISO(this.timeZoneCfg.timeZone);
+    const users = await this.userRepository.find({ select: { id: true } });
+    const chunks = chunk(users, USER_CHUNK_SIZE);
+
+    for (const chunk of chunks) {
+      await Promise.all(
+        chunk.map((user) =>
+          this.missionGenerationService.assignMissionsToUser(user.id, nowZdt),
+        ),
+      );
+    }
+  }
+}

--- a/apps/backend/src/mission/mission-generation/mission-generation.service.ts
+++ b/apps/backend/src/mission/mission-generation/mission-generation.service.ts
@@ -5,7 +5,7 @@ import { Repository } from "typeorm";
 import { MissionAssignment } from "../entities/mission-assignment.entity";
 import { DiagnosisEntry } from "src/diagnosis/entities/diagnosis-entry.entity";
 import { UserProfile } from "src/user/entities/user-profile.entity";
-import { Temporal } from "@js-temporal/polyfill";
+import { Temporal, toTemporalInstant } from "@js-temporal/polyfill";
 import {
   type MissionPicker,
   MISSION_PICKER_TOKEN,
@@ -150,9 +150,12 @@ export class MissionGenerationService {
 
     for (let i = 0; i < entities.length; i++) {
       const entity = entities[i];
+      const lastAssignedAt = raw[i].lastAssignedAt;
       pool[entity.category].push({
         id: entity.id,
-        lastAssignedAt: raw[i].last_assignment_lastAssignedAt ?? null,
+        lastAssignedAt: lastAssignedAt
+          ? toTemporalInstant.call(lastAssignedAt)
+          : null,
       });
     }
 

--- a/apps/backend/src/mission/mission-generation/mission-generation.service.ts
+++ b/apps/backend/src/mission/mission-generation/mission-generation.service.ts
@@ -107,7 +107,7 @@ export class MissionGenerationService {
 
   /**
    * 사용자에 할당 가능한 미션 목록을 카테고리별로 반환한다.
-   * @param userId 사용자
+   * @param userId 사용자: role은 USER여야 한다.
    * @param nowZdt 현재 일시: 최신 assignment 정보 반영에 사용됨
    * @returns 최신 assignment 정보가 포함된, 카테고리별 미션 목록
    */
@@ -115,9 +115,10 @@ export class MissionGenerationService {
     userId: number,
     nowZdt: Temporal.ZonedDateTime,
   ): Promise<AvailableMissionPool> {
-    const profile = (await this.userProfileRepository.findOneBy({
+    // this should never fail.
+    const profile = await this.userProfileRepository.findOneByOrFail({
       userId,
-    }))!;
+    });
 
     const windowCutoff = nowZdt
       .subtract({ days: HISTORY_WINDOW_DAYS })

--- a/apps/backend/src/mission/mission-generation/mission-generation.service.ts
+++ b/apps/backend/src/mission/mission-generation/mission-generation.service.ts
@@ -1,0 +1,236 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { Mission, TestCategory } from "../entities/mission.entity";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { MissionAssignment } from "../entities/mission-assignment.entity";
+import { DiagnosisEntry } from "src/diagnosis/entities/diagnosis-entry.entity";
+import { UserProfile } from "src/user/entities/user-profile.entity";
+import { Temporal } from "@js-temporal/polyfill";
+import {
+  type MissionPicker,
+  MISSION_PICKER_TOKEN,
+} from "./mission-picker/mission-picker.common";
+import { timeZoneConfig } from "src/config";
+import type { ConfigType } from "@nestjs/config";
+import { SimplifiedMission } from "./mission-generation.types";
+
+const HISTORY_WINDOW_DAYS = 7;
+
+const MIN_TOTAL_MISSIONS = 6;
+const MAX_TOTAL_MISSIONS = 8;
+
+type MissionWithAssignment = SimplifiedMission & {
+  lastAssignedAt: Temporal.Instant | null;
+};
+
+type AvailableMissionPool = Record<TestCategory, MissionWithAssignment[]>;
+type AssignmentCounts = Record<TestCategory, number>;
+
+/**
+ * 사용자에 대한 미션 할당을 담당한다.
+ */
+@Injectable()
+export class MissionGenerationService {
+  constructor(
+    @Inject(timeZoneConfig.KEY)
+    private readonly timeZoneCfg: ConfigType<typeof timeZoneConfig>,
+    @InjectRepository(Mission)
+    private readonly missionRepository: Repository<Mission>,
+    @InjectRepository(MissionAssignment)
+    private readonly missionAssignmentRepository: Repository<MissionAssignment>,
+    @InjectRepository(DiagnosisEntry)
+    private readonly diagnosisEntryRepository: Repository<DiagnosisEntry>,
+    @InjectRepository(UserProfile)
+    private readonly userProfileRepository: Repository<UserProfile>,
+    @Inject(MISSION_PICKER_TOKEN)
+    private readonly missionPicker: MissionPicker,
+  ) {}
+
+  /**
+   * 사용자에게 미션들을 할당한다.
+   * @param userId 미션들을 할당할 사용자
+   * @param assignedZdt 미션 할당일
+   * output: DB에 MissionAssignment entity들을 생성한다.
+   * 할당 시 사용자의 자가진단 결과 및 이전 미션 상태를 반영한다.
+   */
+  async assignMissionsToUser(
+    userId: number,
+    assignedZdt: Temporal.ZonedDateTime,
+  ): Promise<void> {
+    const [missionPool, lastDiagnosis] = await Promise.all([
+      this.getAvailableMissions(userId, assignedZdt),
+      this.diagnosisEntryRepository.findOne({
+        where: { userId },
+        order: { createdAt: "DESC" },
+      }),
+    ]);
+
+    const counts = this.getAssignmentCounts(lastDiagnosis);
+
+    const pickedMissions = Object.entries(missionPool).flatMap(
+      ([category, missions]) =>
+        this.missionPicker(
+          missions.map((mission) => ({
+            mission: {
+              id: mission.id,
+            },
+            lastAssignedDay:
+              mission.lastAssignedAt &&
+              assignedZdt.since(
+                mission.lastAssignedAt.toZonedDateTimeISO(
+                  this.timeZoneCfg.timeZone,
+                ),
+                { largestUnit: "day" },
+              ).days,
+          })),
+          counts[category as TestCategory],
+        ),
+    );
+
+    const assignments = pickedMissions.map((mission) =>
+      this.missionAssignmentRepository.create({
+        userId,
+        missionId: mission.id,
+        availableFrom: assignedZdt.withPlainTime().toInstant(),
+        availableUntil: assignedZdt
+          .withPlainTime({
+            hour: 23,
+            minute: 59,
+            second: 59,
+          })
+          .toInstant(),
+      }),
+    );
+
+    await this.missionAssignmentRepository.save(assignments);
+  }
+
+  /**
+   * 사용자에 할당 가능한 미션 목록을 카테고리별로 반환한다.
+   * @param userId 사용자
+   * @param nowZdt 현재 일시: 최신 assignment 정보 반영에 사용됨
+   * @returns 최신 assignment 정보가 포함된, 카테고리별 미션 목록
+   */
+  private async getAvailableMissions(
+    userId: number,
+    nowZdt: Temporal.ZonedDateTime,
+  ): Promise<AvailableMissionPool> {
+    const profile = (await this.userProfileRepository.findOneBy({
+      userId,
+    }))!;
+
+    const windowCutoff = nowZdt
+      .subtract({ days: HISTORY_WINDOW_DAYS })
+      .toInstant()
+      .toString();
+
+    const { entities, raw } = await this.missionRepository
+      .createQueryBuilder("mission")
+      .leftJoinAndMapOne(
+        "mission.lastAssignment",
+        (qb) =>
+          qb
+            .select("la.missionId", "missionId")
+            .addSelect("MAX(la.availableFrom)", "lastAssignedAt")
+            .from(MissionAssignment, "la")
+            .where("la.userId = :userId", { userId })
+            .andWhere("la.availableFrom >= :windowCutoff", { windowCutoff })
+            .groupBy("la.missionId"),
+        "last_assignment",
+        'last_assignment."missionId" = mission.id',
+      )
+      .where("mission.minLevel <= :level", { level: profile.level })
+      .getRawAndEntities();
+
+    const pool: AvailableMissionPool = {
+      [TestCategory.ANXIETY]: [],
+      [TestCategory.DEPRESSION]: [],
+      [TestCategory.STRESS]: [],
+    };
+
+    for (let i = 0; i < entities.length; i++) {
+      const entity = entities[i];
+      pool[entity.category].push({
+        id: entity.id,
+        lastAssignedAt: raw[i].last_assignment_lastAssignedAt ?? null,
+      });
+    }
+
+    return pool;
+  }
+
+  /**
+   * 자가진단의 결과를 가중치로 하여 카테고리별 랜덤한 미션 개수를 반환한다.
+   * @param diagnosis 자가진단 결과
+   * @returns 카테고리별 할당될 미션 개수
+   */
+  private getAssignmentCounts(
+    diagnosis: DiagnosisEntry | null,
+  ): AssignmentCounts {
+    const total =
+      Math.floor(
+        Math.random() * (MAX_TOTAL_MISSIONS - MIN_TOTAL_MISSIONS + 1),
+      ) + MIN_TOTAL_MISSIONS;
+
+    const baseScores: Record<TestCategory, number> = diagnosis
+      ? {
+          [TestCategory.ANXIETY]: diagnosis.anxietyScore,
+          [TestCategory.DEPRESSION]: diagnosis.depressionScore,
+          [TestCategory.STRESS]: diagnosis.stressScore,
+        }
+      : (Object.fromEntries(
+          Object.values(TestCategory).map((c) => [c, 1]),
+        ) as Record<TestCategory, number>);
+
+    const JITTER = 0.2;
+    const noisedScores = Object.fromEntries(
+      Object.entries(baseScores).map(([category, score]) => [
+        category,
+        score * (1 + (Math.random() * 2 - 1) * JITTER),
+      ]),
+    ) as Record<TestCategory, number>;
+
+    return this.scoresToMissionCounts(total, noisedScores) as AssignmentCounts;
+  }
+
+  /**
+   * 총 미션 개수를 카테고리별 점수 비율에 맞게 분배한다.
+   * @param total: total > 0
+   * @param scores: scores.length > 0, scores[i] >= 0
+   */
+  private scoresToMissionCounts<T extends string>(
+    total: number,
+    scores: Record<T, number>,
+  ): Record<T, number> {
+    const scoreTotal = Object.values<number>(scores).reduce((a, b) => a + b, 0);
+    if (scoreTotal === 0) {
+      return this.scoresToMissionCounts(
+        total,
+        Object.fromEntries(Object.keys(scores).map((k) => [k, 1])) as Record<
+          T,
+          number
+        >,
+      );
+    }
+
+    const floored = Object.entries<number>(scores).map(([category, score]) => {
+      const exact = (score / scoreTotal) * total;
+      return {
+        category,
+        count: Math.floor(exact),
+        remainder: exact - Math.floor(exact),
+      };
+    });
+
+    const remaining = total - floored.reduce((a, b) => a + b.count, 0);
+
+    floored
+      .sort((a, b) => b.remainder - a.remainder)
+      .slice(0, remaining)
+      .forEach((entry) => entry.count++);
+
+    return Object.fromEntries(
+      floored.map(({ category, count }) => [category, count]),
+    ) as Record<T, number>;
+  }
+}

--- a/apps/backend/src/mission/mission-generation/mission-generation.types.ts
+++ b/apps/backend/src/mission/mission-generation/mission-generation.types.ts
@@ -1,0 +1,6 @@
+/**
+ * mission generation에 필요한 최소한의 property만 가진 mission
+ */
+export type SimplifiedMission = {
+  id: number;
+};

--- a/apps/backend/src/mission/mission-generation/mission-picker/cooldown-filter-mission-picker.ts
+++ b/apps/backend/src/mission/mission-generation/mission-picker/cooldown-filter-mission-picker.ts
@@ -3,6 +3,8 @@ import { MissionPicker } from "./mission-picker.common";
 const FILTERED_DAYS = 3;
 
 export const cooldownFilterMissionPicker: MissionPicker = (missions, count) => {
+  // assumption: available.length >= count
+  // 현재는 미션 개수가 많다고 가정하기 때문에 잘 작동합니다.
   const available = missions.filter(
     (m) => m.lastAssignedDay === null || m.lastAssignedDay > FILTERED_DAYS,
   );

--- a/apps/backend/src/mission/mission-generation/mission-picker/cooldown-filter-mission-picker.ts
+++ b/apps/backend/src/mission/mission-generation/mission-picker/cooldown-filter-mission-picker.ts
@@ -1,0 +1,13 @@
+import { MissionPicker } from "./mission-picker.common";
+
+const FILTERED_DAYS = 3;
+
+export const cooldownFilterMissionPicker: MissionPicker = (missions, count) => {
+  const available = missions.filter(
+    (m) => m.lastAssignedDay === null || m.lastAssignedDay > FILTERED_DAYS,
+  );
+  return [...available]
+    .sort(() => Math.random() - 0.5)
+    .slice(0, count)
+    .map((m) => m.mission);
+};

--- a/apps/backend/src/mission/mission-generation/mission-picker/mission-picker.common.ts
+++ b/apps/backend/src/mission/mission-generation/mission-picker/mission-picker.common.ts
@@ -1,0 +1,23 @@
+import { SimplifiedMission } from "../mission-generation.types";
+
+export type MissionWithMetadata = {
+  /**
+   * MissionPicker 내부적으로는 black box 취급하는 property
+   */
+  mission: SimplifiedMission;
+  /**
+   * n >= 0
+   * n일 전에 assign 되었음을 의미
+   */
+  lastAssignedDay: number | null;
+};
+
+/**
+ * metadata 기반으로 mission을 pick 한다.
+ */
+export type MissionPicker = (
+  missions: MissionWithMetadata[],
+  count: number,
+) => SimplifiedMission[];
+
+export const MISSION_PICKER_TOKEN = Symbol("MISSION_PICKER");

--- a/apps/backend/src/mission/mission-generation/mission-picker/weighted-mission-picker.ts
+++ b/apps/backend/src/mission/mission-generation/mission-picker/weighted-mission-picker.ts
@@ -1,0 +1,17 @@
+import { type MissionPicker } from "./mission-picker.common";
+
+const MAX_WEIGHT = 7;
+
+export const weightedMissionPicker: MissionPicker = (missions, count) => {
+  const keyed = missions.map(({ mission, lastAssignedDay }) => {
+    const weight = Math.min(MAX_WEIGHT, lastAssignedDay ?? 1);
+
+    // Gumbel-max trick
+    const key = -Math.log(Math.random()) / weight;
+    return { mission, key };
+  });
+
+  keyed.sort((a, b) => b.key - a.key);
+
+  return keyed.slice(0, count).map((k) => k.mission);
+};

--- a/apps/backend/src/mission/mission.module.ts
+++ b/apps/backend/src/mission/mission.module.ts
@@ -22,14 +22,18 @@ import { MissionManagementService } from "./mission-management.service";
 import { MissionGenerationService } from "./mission-generation/mission-generation.service";
 import { MISSION_PICKER_TOKEN } from "./mission-generation/mission-picker/mission-picker.common";
 import { cooldownFilterMissionPicker } from "./mission-generation/mission-picker/cooldown-filter-mission-picker";
+import { MissionGenerationJob } from "./mission-generation/mission-generation.job";
+import { MissionGenerationCron } from "./mission-generation/mission-generation.cron";
+import { User } from "src/user/entities/user.entity";
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
+      DiagnosisEntry,
       Mission,
       MissionAssignment,
       UserProfile,
-      DiagnosisEntry,
+      User,
     ]),
     AuthModule,
     UserModule,
@@ -43,6 +47,8 @@ import { cooldownFilterMissionPicker } from "./mission-generation/mission-picker
     MissionParticipationService,
     MissionManagementService,
     MissionGenerationService,
+    MissionGenerationJob,
+    MissionGenerationCron,
   ],
 })
 export class MissionModule {}

--- a/apps/backend/src/mission/mission.module.ts
+++ b/apps/backend/src/mission/mission.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { Mission } from "./entities/mission.entity";
 import { MissionAssignment } from "./entities/mission-assignment.entity";
 import { UserProfile } from "src/user/entities/user-profile.entity";
+import { DiagnosisEntry } from "src/diagnosis/entities/diagnosis-entry.entity";
 import { MissionParticipationService } from "./mission-participation.service";
 import { AuthModule } from "src/auth/auth.module";
 import { UserModule } from "src/user/user.module";
@@ -18,10 +19,18 @@ import {
 import { MissionAssignmentController } from "./mission-assignment.controller";
 import { MissionAdminController } from "./mission-admin.controller";
 import { MissionManagementService } from "./mission-management.service";
+import { MissionGenerationService } from "./mission-generation/mission-generation.service";
+import { MISSION_PICKER_TOKEN } from "./mission-generation/mission-picker/mission-picker.common";
+import { cooldownFilterMissionPicker } from "./mission-generation/mission-picker/cooldown-filter-mission-picker";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Mission, MissionAssignment, UserProfile]),
+    TypeOrmModule.forFeature([
+      Mission,
+      MissionAssignment,
+      UserProfile,
+      DiagnosisEntry,
+    ]),
     AuthModule,
     UserModule,
   ],
@@ -29,9 +38,11 @@ import { MissionManagementService } from "./mission-management.service";
   providers: [
     { provide: MAX_LEVEL_TOKEN, useValue: MAX_LEVEL },
     { provide: POINTS_FOR_NEXT_LEVEL_TOKEN, useValue: pointsForNextLevel },
+    { provide: MISSION_PICKER_TOKEN, useValue: cooldownFilterMissionPicker },
     LevelCalculatorService,
     MissionParticipationService,
     MissionManagementService,
+    MissionGenerationService,
   ],
 })
 export class MissionModule {}

--- a/apps/backend/src/post/entities/post-like.entity.ts
+++ b/apps/backend/src/post/entities/post-like.entity.ts
@@ -13,17 +13,17 @@ export class PostLike {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ name: "post_id" })
+  @Column()
   postId: number;
 
   @ManyToOne(() => Post, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "post_id" })
+  @JoinColumn()
   post: Post;
 
-  @Column({ name: "user_id" })
+  @Column()
   userId: number;
 
   @ManyToOne(() => User, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "user_id" })
+  @JoinColumn()
   user: User;
 }

--- a/apps/backend/src/post/entities/post.entity.ts
+++ b/apps/backend/src/post/entities/post.entity.ts
@@ -35,17 +35,17 @@ export class Post {
   @Column()
   nickname: string;
 
-  @Column({ name: "author_id" })
+  @Column()
   authorId: number;
 
   @ManyToOne(() => User)
-  @JoinColumn({ name: "author_id" })
+  @JoinColumn()
   author: User;
 
-  @CreateTimestampColumn({ name: "created_at" })
+  @CreateTimestampColumn()
   createdAt: Temporal.Instant;
 
-  @UpdateTimestampColumn({ name: "updated_at" })
+  @UpdateTimestampColumn()
   updatedAt: Temporal.Instant;
 
   @OneToMany(() => Attachment, (attachment) => attachment.post)
@@ -54,6 +54,6 @@ export class Post {
   @OneToMany(() => PostComment, (comment) => comment.post)
   comments: PostComment[];
 
-  @Column({ name: "like_count", default: 0 })
+  @Column({ default: 0 })
   likeCount: number;
 }

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -77,7 +77,7 @@ const orderByMap: Record<
 > = {
   createdAt: {
     path: "post.createdAt",
-    column: 'extract(epoch FROM "post"."created_at")::int',
+    column: "extract(epoch FROM post.createdAt)::int",
     cast: "extract(epoch FROM :cursorValue::timestamp)::int",
     getValue: (post) => post.createdAt.toString(),
   },

--- a/apps/backend/src/resource/entities/resource.entity.ts
+++ b/apps/backend/src/resource/entities/resource.entity.ts
@@ -34,9 +34,9 @@ export class Resource {
   @Column()
   url: string;
 
-  @CreateTimestampColumn({ name: "created_at" })
+  @CreateTimestampColumn()
   createdAt: Temporal.Instant;
 
-  @UpdateTimestampColumn({ name: "updated_at" })
+  @UpdateTimestampColumn()
   updatedAt: Temporal.Instant;
 }

--- a/apps/backend/src/resource/resource-query.service.ts
+++ b/apps/backend/src/resource/resource-query.service.ts
@@ -57,7 +57,7 @@ const orderByMap: Record<
 > = {
   createdAt: {
     path: "resource.createdAt",
-    column: 'extract(epoch FROM "resource"."created_at")::int',
+    column: "extract(epoch FROM resource.createdAt)::int",
     cast: "extract(epoch FROM :cursorValue::timestamp)::int",
     getValue: (resource) => resource.createdAt.toString(),
   },

--- a/apps/backend/src/user/entities/user-profile.entity.ts
+++ b/apps/backend/src/user/entities/user-profile.entity.ts
@@ -24,13 +24,13 @@ export class UserProfile {
   @Column({ default: 1 })
   level: number;
 
-  @Column({ name: "character_index", default: 0 })
+  @Column({ default: 0 })
   characterIndex: number;
 
-  @Column({ name: "user_id" })
+  @Column()
   userId: number;
 
   @OneToOne(() => User, (user) => user.profile, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "user_id" })
+  @JoinColumn()
   user: User;
 }

--- a/apps/backend/src/user/entities/user.entity.ts
+++ b/apps/backend/src/user/entities/user.entity.ts
@@ -31,7 +31,7 @@ export class User {
   @Column({ type: "enum", enum: UserRole, default: UserRole.USER })
   role: UserRole;
 
-  @CreateTimestampColumn({ name: "created_at" })
+  @CreateTimestampColumn()
   createdAt: Temporal.Instant;
 
   @OneToOne(() => UserProfile, (profile) => profile.user, { cascade: true })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       typeorm:
         specifier: ^0.3.28
         version: 0.3.28(ioredis@5.10.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      typeorm-naming-strategies:
+        specifier: ^4.1.0
+        version: 4.1.0(typeorm@0.3.28(ioredis@5.10.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -4301,6 +4304,11 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typeorm-naming-strategies@4.1.0:
+    resolution: {integrity: sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==}
+    peerDependencies:
+      typeorm: ^0.2.0 || ^0.3.0
 
   typeorm@0.3.28:
     resolution: {integrity: sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==}
@@ -9344,6 +9352,10 @@ snapshots:
       is-typed-array: 1.1.15
 
   typedarray@0.0.6: {}
+
+  typeorm-naming-strategies@4.1.0(typeorm@0.3.28(ioredis@5.10.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))):
+    dependencies:
+      typeorm: 0.3.28(ioredis@5.10.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
 
   typeorm@0.3.28(ioredis@5.10.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
+      cron:
+        specifier: ^4.4.0
+        version: 4.4.0
       ioredis:
         specifier: ^5.10.0
         version: 5.10.0


### PR DESCRIPTION
## 요약

#78 부분에 대한 백엔드 부분을 구현하였습니다.

## 내용 (`backend`)

- `MissionGenerationService`: 사용자의 자가진단 및 이전 미션 assignment 기록을 기반으로 미션을 할당합니다.
- `MissionGenerationJob`: 모든 사용자에 대한 미션 할당 batch processing을 진행합니다.
- `MissionGenerationCron`: Nest.JS에서의 scheduling 기능을 통해 미션 할당의 actual scheduling을 진행합니다.
- `mission-picker/` functions: 미션 assignment 기록 기반 미션 할당 로직을 담당하는 함수들입니다. 여러 방식의 로직이 존재하기에 DI 기반으로 switching이 가능하도록 구현하였습니다 (overkill이라고 생각되기는 합니다).
- 리팩토링: entity의 snake case 처리를 기존의 manual 지정 방식에서 `namingStrategy` 옵션 기반으로 처리하도록 변경하였습니다.

## Notes

- non-deterministic 한 로직이라 테스트 코드는 따로 작성하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic daily mission assignment that assigns missions to users at midnight based on their profile level and wellness assessment scores, with intelligent selection to avoid recently assigned tasks.

* **Chores**
  * Updated database naming conventions for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->