### PR TITLE
백엔드 익명 심리 상담 기능 구현

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { CommentModule } from "./comment/comment.module";
 import { ResourceModule } from "./resource/resource.module";
 import { MissionModule } from "./mission/mission.module";
 import { DiagnosisModule } from "./diagnosis/diagnosis.module";
+import { CounselModule } from "./counsel/counsel.module";
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { DiagnosisModule } from "./diagnosis/diagnosis.module";
     ResourceModule,
     MissionModule,
     DiagnosisModule,
+    CounselModule,
   ],
   // 2026-03-18: AuthGuard -- UserService circular dependency 문제를 해결하기
   // 위해 다음과 같이 배치하였습니다.

--- a/apps/backend/src/common/helpers/cursor.ts
+++ b/apps/backend/src/common/helpers/cursor.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { InvalidCursorError } from "../errors/pagination.errors";
+
+export function createCursorCodec<I, O>(schema: z.ZodType<O, I>) {
+  return {
+    encode(payload: O): string {
+      return Buffer.from(JSON.stringify(schema.encode(payload))).toString(
+        "base64url",
+      );
+    },
+
+    decode(cursor: string): O {
+      try {
+        const json = JSON.parse(
+          Buffer.from(cursor, "base64url").toString("utf8"),
+        );
+        return schema.decode(json);
+      } catch {
+        throw new InvalidCursorError();
+      }
+    },
+  };
+}

--- a/apps/backend/src/common/helpers/cursor.ts
+++ b/apps/backend/src/common/helpers/cursor.ts
@@ -5,7 +5,7 @@ import { ObjectLiteral, SelectQueryBuilder } from "typeorm";
 import { InvalidCursorError } from "../errors/pagination.errors";
 
 const cursorPayloadSchema = z.object({
-  value: z.string(),
+  value: z.number(),
   id: z.number(),
 });
 
@@ -79,7 +79,7 @@ export async function executeCursorPagination<T extends ObjectLiteral>(
       items.length > limit && lastItem
         ? cursorCodec.encode({
             id: lastItem.id,
-            value: String(orderByField.toCursorValue(lastItem)),
+            value: orderByField.toCursorValue(lastItem),
           })
         : undefined,
   };

--- a/apps/backend/src/common/helpers/cursor.ts
+++ b/apps/backend/src/common/helpers/cursor.ts
@@ -1,23 +1,86 @@
+// helpers for cursor pagination in services.
+
 import { z } from "zod";
+import { ObjectLiteral, SelectQueryBuilder } from "typeorm";
 import { InvalidCursorError } from "../errors/pagination.errors";
 
-export function createCursorCodec<I, O>(schema: z.ZodType<O, I>) {
-  return {
-    encode(payload: O): string {
-      return Buffer.from(JSON.stringify(schema.encode(payload))).toString(
-        "base64url",
-      );
-    },
+const cursorPayloadSchema = z.object({
+  value: z.string(),
+  id: z.number(),
+});
 
-    decode(cursor: string): O {
-      try {
-        const json = JSON.parse(
-          Buffer.from(cursor, "base64url").toString("utf8"),
-        );
-        return schema.decode(json);
-      } catch {
-        throw new InvalidCursorError();
-      }
-    },
+type CursorPayload = z.output<typeof cursorPayloadSchema>;
+
+const cursorCodec = {
+  encode(payload: CursorPayload): string {
+    return Buffer.from(JSON.stringify(payload)).toString("base64url");
+  },
+
+  decode(cursor: string): CursorPayload {
+    try {
+      const json = JSON.parse(
+        Buffer.from(cursor, "base64url").toString("utf8"),
+      );
+      return cursorPayloadSchema.parse(json);
+    } catch {
+      throw new InvalidCursorError();
+    }
+  },
+};
+
+export type ExecuteCursorPaginationOptions<T extends ObjectLiteral> = {
+  cursor?: string | undefined;
+  orderByField: {
+    // see post-query.service.ts
+    sqlPath: string; // 'path'
+    sqlCursorValue: string; // 'column'
+    toCursorValue: (entity: T) => number; // 'getValue'
+  };
+  orderDirection: "asc" | "desc";
+  limit: number;
+};
+
+export type ExecuteCursorPaginationResult<T> = {
+  items: T[];
+  nextCursor: string | undefined;
+};
+
+export async function executeCursorPagination<T extends ObjectLiteral>(
+  qb: SelectQueryBuilder<T>,
+  {
+    cursor,
+    orderByField,
+    orderDirection,
+    limit,
+  }: ExecuteCursorPaginationOptions<T>,
+): Promise<ExecuteCursorPaginationResult<T>> {
+  const decodedCursor = cursor ? cursorCodec.decode(cursor) : undefined;
+  const sqlDirection = orderDirection === "asc" ? "ASC" : "DESC";
+  const cursorOp = orderDirection === "asc" ? ">" : "<";
+
+  if (decodedCursor) {
+    qb.andWhere(
+      `(${orderByField.sqlCursorValue}, "${qb.alias}"."id") ${cursorOp} (:cursorValue::int, :cursorId::int)`,
+      { cursorValue: decodedCursor.value, cursorId: decodedCursor.id },
+    );
+  }
+
+  const items = await qb
+    .orderBy(orderByField.sqlPath, sqlDirection)
+    .addOrderBy(`${qb.alias}.id`, sqlDirection)
+    .take(limit + 1)
+    .getMany();
+
+  const resultItems = items.slice(0, limit);
+  const lastItem = resultItems.at(-1);
+  return {
+    items: resultItems,
+    nextCursor:
+      items.length > limit && lastItem
+        ? cursorCodec.encode({
+            id: lastItem.id,
+            value: String(orderByField.toCursorValue(lastItem)),
+          })
+        : undefined,
   };
 }

--- a/apps/backend/src/common/helpers/pagination.ts
+++ b/apps/backend/src/common/helpers/pagination.ts
@@ -1,3 +1,5 @@
+// types for pagination methods in services.
+
 export type CursorPaginationOptions<OrderBy extends string> = {
   cursor?: string;
   limit: number;

--- a/apps/backend/src/counsel/counsel-admin.controller.ts
+++ b/apps/backend/src/counsel/counsel-admin.controller.ts
@@ -1,0 +1,108 @@
+import type {
+  AdminGetCounselSuccessResponseDto,
+  AdminListCounselsQueryDto,
+  AdminListCounselsSuccessResponseDto,
+  AdminRespondToCounselRequestDto,
+  AdminRespondToCounselSuccessResponseDto,
+} from "@mindseed/api-types";
+import {
+  AdminGetCounselResponseDtoSchema,
+  AdminListCounselsQueryDtoSchema,
+  AdminListCounselsResponseDtoSchema,
+  AdminRespondToCounselRequestDtoSchema,
+  AdminRespondToCounselResponseDtoSchema,
+  idParamSchema,
+} from "@mindseed/api-types";
+import { Controller, Get, HttpCode, HttpStatus, Post } from "@nestjs/common";
+import { AdminOnly, CurrentUser } from "src/auth/decorators/auth.decorators";
+import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
+import {
+  ZodBody,
+  ZodParam,
+  ZodQuery,
+} from "src/common/pipes/zod-validation.decorator";
+import { User } from "src/user/entities/user.entity";
+import { CounselMutationService } from "./counsel-mutation.service";
+import { CounselQueryService } from "./counsel-query.service";
+import { categoryMap } from "./counsel.mappers";
+
+@Controller("/admin/counsels")
+export class CounselAdminController {
+  constructor(
+    private readonly counselQueryService: CounselQueryService,
+    private readonly counselMutationService: CounselMutationService,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @AdminOnly()
+  @ZodEncodeResponse(AdminListCounselsResponseDtoSchema)
+  async listCounsels(
+    @ZodQuery(AdminListCounselsQueryDtoSchema) query: AdminListCounselsQueryDto,
+  ): Promise<AdminListCounselsSuccessResponseDto> {
+    const { items, hasNext } =
+      await this.counselQueryService.listCounselEntriesWithOffset({
+        offset: query.offset,
+        limit: query.limit,
+        category: query.category
+          ? categoryMap.decode(query.category)
+          : undefined,
+        responded: query.responded,
+        orderBy: query.orderBy,
+        orderDirection: query.orderDirection,
+      });
+
+    return {
+      success: true,
+      data: {
+        items: items.map((counsel) => ({
+          id: counsel.id,
+          title: counsel.title,
+          category: categoryMap.encode(counsel.category),
+          createdAt: counsel.createdAt,
+          responded: counsel.responseContent !== null,
+        })),
+        hasNext,
+      },
+    };
+  }
+
+  @Get(":id")
+  @HttpCode(HttpStatus.OK)
+  @AdminOnly()
+  @ZodEncodeResponse(AdminGetCounselResponseDtoSchema)
+  async getCounsel(
+    @ZodParam("id", idParamSchema) id: number,
+  ): Promise<AdminGetCounselSuccessResponseDto> {
+    const entry = await this.counselQueryService.getCounselEntry(id);
+    return {
+      success: true,
+      data: {
+        id: entry.id,
+        title: entry.title,
+        content: entry.content,
+        category: categoryMap.encode(entry.category),
+        createdAt: entry.createdAt,
+        response: entry.responseContent ?? undefined,
+      },
+    };
+  }
+
+  @Post(":id/response")
+  @HttpCode(HttpStatus.OK)
+  @AdminOnly()
+  @ZodEncodeResponse(AdminRespondToCounselResponseDtoSchema)
+  async respondToCounsel(
+    @CurrentUser() user: User,
+    @ZodParam("id", idParamSchema) id: number,
+    @ZodBody(AdminRespondToCounselRequestDtoSchema)
+    body: AdminRespondToCounselRequestDto,
+  ): Promise<AdminRespondToCounselSuccessResponseDto> {
+    await this.counselMutationService.respondToCounselEntry(
+      id,
+      user.id,
+      body.response,
+    );
+    return { success: true, data: null };
+  }
+}

--- a/apps/backend/src/counsel/counsel-mutation.service.spec.ts
+++ b/apps/backend/src/counsel/counsel-mutation.service.spec.ts
@@ -1,0 +1,282 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { DataSource, Repository } from "typeorm";
+import PGMem from "pg-mem";
+import { CounselMutationService } from "./counsel-mutation.service";
+import {
+  CounselNotFoundError,
+  NotCounselAuthorError,
+  CounselAlreadyRespondedError,
+} from "./counsel.errors";
+import { CounselEntry, CounselCategory } from "./entities/counsel-entry.entity";
+import { User, UserRole } from "src/user/entities/user.entity";
+import { initializePgMem } from "src/test/pg-mem.helper";
+import { UserProfile } from "src/user/entities/user-profile.entity";
+
+const entities = [User, UserProfile, CounselEntry];
+
+describe("CounselMutationService", () => {
+  let module: TestingModule;
+  let counselMutationService: CounselMutationService;
+  let counselEntryRepository: Repository<CounselEntry>;
+  let userRepository: Repository<User>;
+  let dataSource: DataSource;
+  let dbBackup: PGMem.IBackup;
+
+  let userCounter = 0;
+
+  async function saveTestUser(overrides?: Partial<User>): Promise<User> {
+    return userRepository.save(
+      userRepository.create({
+        email: `user${++userCounter}@test.com`,
+        password: "password",
+        role: UserRole.USER,
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestCounsel(
+    userId: number,
+    overrides?: Partial<CounselEntry>,
+  ): Promise<CounselEntry> {
+    return counselEntryRepository.save(
+      counselEntryRepository.create({
+        authorId: userId,
+        title: "test title",
+        content: "test content",
+        category: CounselCategory.ANXIETY,
+        responseContent: null,
+        responderId: null,
+        ...overrides,
+      }),
+    );
+  }
+
+  beforeAll(async () => {
+    const { dataSource: ds, backup } = await initializePgMem(entities);
+    dataSource = ds;
+    dbBackup = backup;
+
+    module = await Test.createTestingModule({
+      providers: [
+        CounselMutationService,
+        {
+          provide: getRepositoryToken(CounselEntry),
+          useValue: dataSource.getRepository(CounselEntry),
+        },
+      ],
+    }).compile();
+
+    counselMutationService = module.get(CounselMutationService);
+    counselEntryRepository = dataSource.getRepository(CounselEntry);
+    userRepository = dataSource.getRepository(User);
+  });
+
+  beforeEach(() => {
+    dbBackup.restore();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+    await module.close();
+  });
+
+  describe("createCounsel", () => {
+    it("success: counsel entry 생성", async () => {
+      // Given
+      const user = await saveTestUser();
+
+      // When: counsel entry 생성 시도
+      const counsel = await counselMutationService.createCounselEntry({
+        userId: user.id,
+        title: "title",
+        content: "content",
+        category: CounselCategory.ANXIETY,
+      });
+
+      // Then: counsel entry가 올바르게 생성됨
+      const saved = await counselEntryRepository.findOneBy({ id: counsel.id });
+      expect(saved).toMatchObject({
+        authorId: user.id,
+        title: "title",
+        content: "content",
+        category: CounselCategory.ANXIETY,
+        responseContent: null,
+      });
+    });
+  });
+
+  describe("updateCounsel", () => {
+    it("success: counsel entry 업데이트", async () => {
+      // Given: 존재하는 counsel entry 및 올바른 작성자인 경우
+      const user = await saveTestUser();
+      const counsel = await saveTestCounsel(user.id);
+
+      // When: counsel entry 업데이트 시도
+      await counselMutationService.updateCounselEntry({
+        id: counsel.id,
+        userId: user.id,
+        title: "updated title",
+        content: "updated content",
+        category: CounselCategory.STRESS,
+      });
+
+      // Then: counsel entry 업데이트됨
+      const updated = await counselEntryRepository.findOneBy({
+        id: counsel.id,
+      });
+      expect(updated).toMatchObject({
+        title: "updated title",
+        content: "updated content",
+        category: CounselCategory.STRESS,
+      });
+    });
+
+    it("존재하지 않는 counsel entry 처리", async () => {
+      // Given: counsel entry가 존재하지 않는 경우
+      const user = await saveTestUser();
+      const nonExistentId = 0;
+
+      // When: counsel entry 업데이트 시도
+      const result = counselMutationService.updateCounselEntry({
+        id: nonExistentId,
+        userId: user.id,
+        title: "title",
+        content: "content",
+        category: CounselCategory.ANXIETY,
+      });
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(CounselNotFoundError);
+    });
+
+    it("counsel entry 작성자가 아닌 경우 처리", async () => {
+      // Given: counsel entry가 존재하지만, 작성자가 일치하지 않는 경우
+      const user = await saveTestUser();
+      const otherUser = await saveTestUser();
+      const counsel = await saveTestCounsel(otherUser.id);
+
+      // When: counsel entry 업데이트 시도
+      const result = counselMutationService.updateCounselEntry({
+        id: counsel.id,
+        userId: user.id,
+        title: "title",
+        content: "content",
+        category: CounselCategory.ANXIETY,
+      });
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(NotCounselAuthorError);
+    });
+  });
+
+  describe("deleteCounsel", () => {
+    it("success: counsel entry 삭제", async () => {
+      // Given: 존재하는 counsel entry 및 작성자인 경우
+      const user = await saveTestUser();
+      const counsel = await saveTestCounsel(user.id);
+
+      // When: counsel entry 삭제 시도
+      await counselMutationService.deleteCounselEntry(counsel.id, user.id);
+
+      // Then: counsel entry 삭제됨
+      expect(
+        await counselEntryRepository.findOneBy({ id: counsel.id }),
+      ).toBeNull();
+    });
+
+    it("존재하지 않는 counsel entry 처리", async () => {
+      // Given: counsel entry가 존재하지 않는 경우
+      const user = await saveTestUser();
+      const nonExistentId = 0;
+
+      // When: counsel entry 삭제 시도
+      const result = counselMutationService.deleteCounselEntry(
+        nonExistentId,
+        user.id,
+      );
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(CounselNotFoundError);
+    });
+
+    it("counsel entry 작성자가 아닌 경우 처리", async () => {
+      // Given: counsel entry가 존재하지만, 작성자가 일치하지 않는 경우
+      const user = await saveTestUser();
+      const otherUser = await saveTestUser();
+      const counsel = await saveTestCounsel(otherUser.id);
+
+      // When: counsel entry 삭제 시도
+      const result = counselMutationService.deleteCounselEntry(
+        counsel.id,
+        user.id,
+      );
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(NotCounselAuthorError);
+    });
+  });
+
+  describe("respondToCounsel", () => {
+    it("success: counsel entry 답변 등록", async () => {
+      // Given: 존재하는 counsel entry이며, 답변이 없는 경우
+      const author = await saveTestUser();
+      const admin = await saveTestUser({ role: UserRole.ADMIN });
+      const counsel = await saveTestCounsel(author.id);
+
+      // When: counsel entry 답변 시도
+      await counselMutationService.respondToCounselEntry(
+        counsel.id,
+        admin.id,
+        "response content",
+      );
+
+      // Then: responseContent 및 responderId 업데이트됨
+      const responded = await counselEntryRepository.findOneBy({
+        id: counsel.id,
+      });
+      expect(responded).toMatchObject({
+        responderId: admin.id,
+        responseContent: "response content",
+      });
+    });
+
+    it("존재하지 않는 counsel entry 처리", async () => {
+      // Given: counsel entry가 존재하지 않는 경우
+      const admin = await saveTestUser({ role: UserRole.ADMIN });
+      const nonExistentId = 0;
+
+      // When: counsel entry 답변 시도
+      const result = counselMutationService.respondToCounselEntry(
+        nonExistentId,
+        admin.id,
+        "response content",
+      );
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(CounselNotFoundError);
+    });
+
+    it("이미 답변된 counsel entry 처리", async () => {
+      // Given: counsel entry가 이미 답변된 경우
+      const author = await saveTestUser();
+      const admin = await saveTestUser({ role: UserRole.ADMIN });
+      const counsel = await saveTestCounsel(author.id, {
+        responderId: admin.id,
+        responseContent: "existing response",
+      });
+
+      // When: counsel entry 답변 시도
+      const result = counselMutationService.respondToCounselEntry(
+        counsel.id,
+        admin.id,
+        "new response",
+      );
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(CounselAlreadyRespondedError);
+    });
+  });
+});

--- a/apps/backend/src/counsel/counsel-mutation.service.ts
+++ b/apps/backend/src/counsel/counsel-mutation.service.ts
@@ -1,0 +1,123 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { CounselCategory, CounselEntry } from "./entities/counsel-entry.entity";
+import {
+  CounselAlreadyRespondedError,
+  CounselNotFoundError,
+  NotCounselAuthorError,
+} from "./counsel.errors";
+
+export type CreateCounselOptions = {
+  userId: number;
+  title: string;
+  content: string;
+  category: CounselCategory;
+};
+
+export type UpdateCounselOptions = {
+  id: number;
+  userId: number;
+  title: string;
+  content: string;
+  category: CounselCategory;
+};
+
+/**
+ * counsel entry의 mutation과 관련된 부분을 담당한다.
+ */
+@Injectable()
+export class CounselMutationService {
+  constructor(
+    @InjectRepository(CounselEntry)
+    private readonly counselEntryRepository: Repository<CounselEntry>,
+  ) {}
+
+  /**
+   * options를 기반으로 counsel entry를 생성한다.
+   * assumption: options.userId: USER role로 존재하는 사용자의 id이다.
+   * @returns 생성된 counsel entry
+   */
+  async createCounselEntry(
+    options: CreateCounselOptions,
+  ): Promise<CounselEntry> {
+    return this.counselEntryRepository.save(
+      this.counselEntryRepository.create({
+        authorId: options.userId,
+        title: options.title,
+        content: options.content,
+        category: options.category,
+        responseContent: null,
+        responderId: null,
+      }),
+    );
+  }
+
+  /**
+   * options.userId의 사용자가 counsel entry의 작성자인 경우, entry를
+   * 업데이트한다.
+   * assumption: options.userId: USER role로 존재하는 사용자의 id이다.
+   */
+  async updateCounselEntry({
+    id,
+    userId,
+    title,
+    content,
+    category,
+  }: UpdateCounselOptions): Promise<void> {
+    const counsel = await this.counselEntryRepository.findOneBy({ id });
+    if (!counsel) {
+      throw new CounselNotFoundError();
+    }
+    if (counsel.authorId !== userId) {
+      throw new NotCounselAuthorError();
+    }
+
+    await this.counselEntryRepository.save({
+      ...counsel,
+      title,
+      content,
+      category,
+    });
+  }
+
+  /**
+   * userId의 사용자가 counsel entry의 작성자인 경우, entry를 삭제한다.
+   * assumption: userId: USER role로 존재하는 사용자의 id이다.
+   */
+  async deleteCounselEntry(id: number, userId: number): Promise<void> {
+    const counsel = await this.counselEntryRepository.findOneBy({ id });
+    if (!counsel) {
+      throw new CounselNotFoundError();
+    }
+    if (counsel.authorId !== userId) {
+      throw new NotCounselAuthorError();
+    }
+
+    await this.counselEntryRepository.delete(id);
+  }
+
+  /**
+   * responderId와 responseContent를 기반으로 counsel entry에 응답을 추가한다.
+   * assumption: responderId: ADMIN role로 존재하는 사용자의 id이다.
+   */
+  async respondToCounselEntry(
+    id: number,
+    responderId: number,
+    responseContent: string,
+  ): Promise<void> {
+    const counsel = await this.counselEntryRepository.findOneBy({ id });
+    if (!counsel) {
+      throw new CounselNotFoundError();
+    }
+    if (counsel.responseContent !== null) {
+      throw new CounselAlreadyRespondedError();
+    }
+
+    await this.counselEntryRepository.save({
+      ...counsel,
+      responderId,
+      responseContent,
+    });
+  }
+}

--- a/apps/backend/src/counsel/counsel-query.service.spec.ts
+++ b/apps/backend/src/counsel/counsel-query.service.spec.ts
@@ -252,7 +252,7 @@ describe("CounselQueryService", () => {
       });
 
       // Then: throws handled error
-      expect(result).rejects.toThrow(InvalidCursorError);
+      await expect(result).rejects.toThrow(InvalidCursorError);
     });
   });
 

--- a/apps/backend/src/counsel/counsel-query.service.spec.ts
+++ b/apps/backend/src/counsel/counsel-query.service.spec.ts
@@ -1,0 +1,292 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { DataSource, Repository } from "typeorm";
+import PGMem from "pg-mem";
+import { CounselQueryService } from "./counsel-query.service";
+import { CounselNotFoundError } from "./counsel.errors";
+import { InvalidCursorError } from "src/common/errors/pagination.errors";
+import { CounselEntry, CounselCategory } from "./entities/counsel-entry.entity";
+import { User, UserRole } from "src/user/entities/user.entity";
+import { UserProfile } from "src/user/entities/user-profile.entity";
+import { initializePgMem } from "src/test/pg-mem.helper";
+
+const entities = [User, UserProfile, CounselEntry];
+
+describe("CounselQueryService", () => {
+  let module: TestingModule;
+  let counselQueryService: CounselQueryService;
+  let counselEntryRepository: Repository<CounselEntry>;
+  let userRepository: Repository<User>;
+  let dataSource: DataSource;
+  let dbBackup: PGMem.IBackup;
+
+  let userCounter = 0;
+
+  async function saveTestUser(overrides?: Partial<User>): Promise<User> {
+    return userRepository.save(
+      userRepository.create({
+        email: `user${++userCounter}@test.com`,
+        password: "password",
+        role: UserRole.USER,
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestCounsel(
+    userId: number,
+    overrides?: Partial<CounselEntry>,
+  ): Promise<CounselEntry> {
+    return counselEntryRepository.save(
+      counselEntryRepository.create({
+        authorId: userId,
+        title: "test title",
+        content: "test content",
+        category: CounselCategory.ANXIETY,
+        responseContent: null,
+        responderId: null,
+        ...overrides,
+      }),
+    );
+  }
+
+  async function saveTestCounsels(
+    userId: number,
+    overridesList: Partial<CounselEntry>[],
+  ): Promise<number[]> {
+    const ids: number[] = [];
+    for (const overrides of overridesList) {
+      ids.push((await saveTestCounsel(userId, overrides)).id);
+    }
+    return ids;
+  }
+
+  beforeAll(async () => {
+    const { dataSource: ds, backup } = await initializePgMem(entities);
+    dataSource = ds;
+    dbBackup = backup;
+
+    module = await Test.createTestingModule({
+      providers: [
+        CounselQueryService,
+        {
+          provide: getRepositoryToken(CounselEntry),
+          useValue: dataSource.getRepository(CounselEntry),
+        },
+      ],
+    }).compile();
+
+    counselQueryService = module.get(CounselQueryService);
+    counselEntryRepository = dataSource.getRepository(CounselEntry);
+    userRepository = dataSource.getRepository(User);
+  });
+
+  beforeEach(() => {
+    dbBackup.restore();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+    await module.close();
+  });
+
+  describe("listCounselEntriesWithOffset", () => {
+    it("success: 각 parameter 처리", async () => {
+      // Given
+      const user = await saveTestUser();
+      const admin = await saveTestUser({ role: UserRole.ADMIN });
+      const ids = await saveTestCounsels(user.id, [
+        {
+          category: CounselCategory.ANXIETY,
+          responseContent: null,
+          responderId: null,
+        },
+        {
+          category: CounselCategory.STRESS,
+          responseContent: null,
+          responderId: null,
+        },
+        {
+          category: CounselCategory.ANXIETY,
+          responseContent: null,
+          responderId: null,
+        },
+        {
+          category: CounselCategory.ANXIETY,
+          responseContent: "response",
+          responderId: admin.id,
+        },
+        {
+          category: CounselCategory.ANXIETY,
+          responseContent: null,
+          responderId: null,
+        },
+      ]);
+
+      // When: 첫 페이지 조회
+      const result = await counselQueryService.listCounselEntriesWithOffset({
+        offset: 0,
+        limit: 2,
+        category: CounselCategory.ANXIETY,
+        responded: false,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+
+      // Then: 올바른 결과 반환
+      expect(result.items.map((e) => e.id)).toEqual([ids[0], ids[2]]);
+      expect(result.hasNext).toBe(true);
+
+      // When: 다음 페이지 조회
+      const result2 = await counselQueryService.listCounselEntriesWithOffset({
+        offset: 2,
+        limit: 2,
+        category: CounselCategory.ANXIETY,
+        responded: false,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+
+      // Then: 올바른 결과 반환
+      expect(result2.items.map((e) => e.id)).toEqual([ids[4]]);
+      expect(result2.hasNext).toBe(false);
+    });
+  });
+
+  describe("listCounselEntriesWithCursor", () => {
+    it("success: 각 parameter 처리", async () => {
+      // Given
+      const user = await saveTestUser();
+      const admin = await saveTestUser({ role: UserRole.ADMIN });
+      const ids = await saveTestCounsels(user.id, [
+        {
+          category: CounselCategory.ANXIETY,
+          responseContent: null,
+          responderId: null,
+        },
+        {
+          category: CounselCategory.STRESS,
+          responseContent: null,
+          responderId: null,
+        },
+        {
+          category: CounselCategory.ANXIETY,
+          responseContent: null,
+          responderId: null,
+        },
+        {
+          category: CounselCategory.ANXIETY,
+          responseContent: "response",
+          responderId: admin.id,
+        },
+        {
+          category: CounselCategory.ANXIETY,
+          responseContent: null,
+          responderId: null,
+        },
+      ]);
+
+      // When: 첫 페이지 조회
+      const result1 = await counselQueryService.listCounselEntriesWithCursor({
+        limit: 2,
+        category: CounselCategory.ANXIETY,
+        responded: false,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+
+      // Then: 올바른 결과 반환
+      expect(result1.items.map((e) => e.id)).toEqual([ids[0], ids[2]]);
+      expect(result1.nextCursor).toBeDefined();
+
+      // When: 다음 페이지 조회
+      const result2 = await counselQueryService.listCounselEntriesWithCursor({
+        cursor: result1.nextCursor,
+        limit: 2,
+        category: CounselCategory.ANXIETY,
+        responded: false,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+
+      // Then: 올바른 결과 반환
+      expect(result2.items.map((e) => e.id)).toEqual([ids[4]]);
+      expect(result2.nextCursor).toBeUndefined();
+    });
+
+    it("success: cursor에 해당하는 counsel entry가 삭제된 경우 올바르게 처리", async () => {
+      // Given: cursor에 해당하는 counsel entry가 삭제된 경우
+      const user = await saveTestUser();
+      const ids = await saveTestCounsels(user.id, [{}, {}, {}]);
+
+      const firstPage = await counselQueryService.listCounselEntriesWithCursor({
+        limit: 1,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+      await counselEntryRepository.delete(ids[0]);
+
+      // When: 조회 시도
+      const result = await counselQueryService.listCounselEntriesWithCursor({
+        cursor: firstPage.nextCursor,
+        limit: 2,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+
+      // Then: 삭제된 counsel entry 다음부터 올바르게 반환
+      expect(result.items.map((e) => e.id)).toEqual([ids[1], ids[2]]);
+    });
+
+    it("올바르지 않은 형식의 cursor인 경우 처리", async () => {
+      // Given: 올바르지 않은 형식의 cursor
+      const malformedCursor = "arst";
+
+      // When: 조회 시도
+      const result = counselQueryService.listCounselEntriesWithCursor({
+        cursor: malformedCursor,
+        limit: 1,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+      });
+
+      // Then: throws handled error
+      expect(result).rejects.toThrow(InvalidCursorError);
+    });
+  });
+
+  describe("getCounselEntry", () => {
+    it("success: counsel entry 반환", async () => {
+      // Given: 존재하는 counsel entry
+      const user = await saveTestUser();
+      const counsel = await saveTestCounsel(user.id, {
+        title: "hello",
+        content: "world",
+        category: CounselCategory.STRESS,
+      });
+
+      // When: counsel entry 조회 시도
+      const result = await counselQueryService.getCounselEntry(counsel.id);
+
+      // Then: 올바른 counsel entry 반환
+      expect(result).toMatchObject({
+        id: counsel.id,
+        title: "hello",
+        content: "world",
+        category: CounselCategory.STRESS,
+      });
+    });
+
+    it("존재하지 않는 counsel entry 처리", async () => {
+      // Given: counsel entry가 존재하지 않는 경우
+      const nonExistentId = 0;
+
+      // When: counsel entry 조회 시도
+      const result = counselQueryService.getCounselEntry(nonExistentId);
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(CounselNotFoundError);
+    });
+  });
+});

--- a/apps/backend/src/counsel/counsel-query.service.ts
+++ b/apps/backend/src/counsel/counsel-query.service.ts
@@ -1,0 +1,136 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { CounselCategory, CounselEntry } from "./entities/counsel-entry.entity";
+import { CounselNotFoundError } from "./counsel.errors";
+import {
+  CursorPaginationOptions,
+  CursorPaginationResult,
+  OffsetPaginationOptions,
+  OffsetPaginationResult,
+} from "src/common/helpers/pagination";
+import { executeCursorPagination } from "src/common/helpers/cursor";
+
+export type ListCounselEntriesOrderBy = "createdAt";
+
+export type ListCounselEntriesWithOffsetOptions =
+  OffsetPaginationOptions<ListCounselEntriesOrderBy> & {
+    category?: CounselCategory;
+    responded?: boolean;
+  };
+
+export type ListCounselEntriesWithOffsetResult =
+  OffsetPaginationResult<CounselEntry>;
+
+export type ListCounselEntriesWithCursorOptions =
+  CursorPaginationOptions<ListCounselEntriesOrderBy> & {
+    category?: CounselCategory;
+    responded?: boolean;
+  };
+
+export type ListCounselEntriesWithCursorResult =
+  CursorPaginationResult<CounselEntry>;
+
+const orderByMap = {
+  createdAt: {
+    sqlPath: "counsel.createdAt",
+    sqlCursorValue: "extract(epoch FROM counsel.createdAt)::int",
+    toCursorValue: (entry: CounselEntry) =>
+      Math.floor(entry.createdAt.epochMilliseconds / 1000),
+  },
+} satisfies Record<ListCounselEntriesOrderBy, object>;
+
+/**
+ * CounselEntry의 조회와 관련된 부분을 담당한다.
+ */
+@Injectable()
+export class CounselQueryService {
+  constructor(
+    @InjectRepository(CounselEntry)
+    private readonly counselEntryRepository: Repository<CounselEntry>,
+  ) {}
+
+  /**
+   * offset-based pagination option을 적용하여 counsel entry 목록을 조회한다.
+   */
+  async listCounselEntriesWithOffset({
+    offset,
+    limit,
+    category,
+    responded,
+    orderBy,
+    orderDirection,
+  }: ListCounselEntriesWithOffsetOptions): Promise<ListCounselEntriesWithOffsetResult> {
+    const qb = this.counselEntryRepository.createQueryBuilder("counsel");
+
+    if (category) {
+      qb.where("counsel.category = :category", { category });
+    }
+    if (responded !== undefined) {
+      qb.andWhere(
+        responded
+          ? "counsel.responseContent IS NOT NULL"
+          : "counsel.responseContent IS NULL",
+      );
+    }
+
+    const orderEntry = orderByMap[orderBy];
+    const sqlDirection = orderDirection === "asc" ? "ASC" : "DESC";
+
+    const items = await qb
+      .orderBy(orderEntry.sqlPath, sqlDirection)
+      .addOrderBy("counsel.id", sqlDirection)
+      .skip(offset)
+      .take(limit + 1)
+      .getMany();
+
+    return {
+      items: items.slice(0, limit),
+      hasNext: items.length > limit,
+    };
+  }
+
+  /**
+   * cursor-based pagination option을 적용하여 counsel entry 목록을 조회한다.
+   */
+  async listCounselEntriesWithCursor({
+    cursor,
+    limit,
+    category,
+    responded,
+    orderBy,
+    orderDirection,
+  }: ListCounselEntriesWithCursorOptions): Promise<ListCounselEntriesWithCursorResult> {
+    const qb = this.counselEntryRepository.createQueryBuilder("counsel");
+
+    if (category) {
+      qb.where("counsel.category = :category", { category });
+    }
+    if (responded !== undefined) {
+      qb.andWhere(
+        responded
+          ? "counsel.responseContent IS NOT NULL"
+          : "counsel.responseContent IS NULL",
+      );
+    }
+
+    return executeCursorPagination(qb, {
+      cursor,
+      orderByField: orderByMap[orderBy],
+      orderDirection,
+      limit,
+    });
+  }
+
+  /**
+   * id를 기반으로 counsel entry를 조회한다.
+   * @throws CounselNotFoundError - counsel entry가 존재하지 않는 경우
+   */
+  async getCounselEntry(id: number): Promise<CounselEntry> {
+    const entry = await this.counselEntryRepository.findOneBy({ id });
+    if (!entry) {
+      throw new CounselNotFoundError();
+    }
+    return entry;
+  }
+}

--- a/apps/backend/src/counsel/counsel.controller.ts
+++ b/apps/backend/src/counsel/counsel.controller.ts
@@ -1,0 +1,152 @@
+import type {
+  CreateCounselRequestDto,
+  CreateCounselSuccessResponseDto,
+  DeleteCounselSuccessResponseDto,
+  GetCounselSuccessResponseDto,
+  ListCounselsQueryDto,
+  ListCounselsSuccessResponseDto,
+  UpdateCounselRequestDto,
+  UpdateCounselSuccessResponseDto,
+} from "@mindseed/api-types";
+import {
+  CreateCounselRequestDtoSchema,
+  CreateCounselResponseDtoSchema,
+  DeleteCounselResponseDtoSchema,
+  GetCounselResponseDtoSchema,
+  idParamSchema,
+  ListCounselsQueryDtoSchema,
+  ListCounselsResponseDtoSchema,
+  UpdateCounselRequestDtoSchema,
+  UpdateCounselResponseDtoSchema,
+} from "@mindseed/api-types";
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Put,
+} from "@nestjs/common";
+import { CurrentUser, UserOnly } from "src/auth/decorators/auth.decorators";
+import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
+import {
+  ZodBody,
+  ZodParam,
+  ZodQuery,
+} from "src/common/pipes/zod-validation.decorator";
+import { User } from "src/user/entities/user.entity";
+import { CounselMutationService } from "./counsel-mutation.service";
+import { CounselQueryService } from "./counsel-query.service";
+import { categoryMap } from "./counsel.mappers";
+
+@Controller("/counsels")
+export class CounselController {
+  constructor(
+    private readonly counselQueryService: CounselQueryService,
+    private readonly counselMutationService: CounselMutationService,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UserOnly()
+  @ZodEncodeResponse(CreateCounselResponseDtoSchema)
+  async createCounsel(
+    @CurrentUser() user: User,
+    @ZodBody(CreateCounselRequestDtoSchema) body: CreateCounselRequestDto,
+  ): Promise<CreateCounselSuccessResponseDto> {
+    const entry = await this.counselMutationService.createCounselEntry({
+      userId: user.id,
+      title: body.title,
+      content: body.content,
+      category: categoryMap.decode(body.category),
+    });
+    return { success: true, data: { id: entry.id } };
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(ListCounselsResponseDtoSchema)
+  async listCounsels(
+    @ZodQuery(ListCounselsQueryDtoSchema) query: ListCounselsQueryDto,
+  ): Promise<ListCounselsSuccessResponseDto> {
+    const { items, nextCursor } =
+      await this.counselQueryService.listCounselEntriesWithCursor({
+        cursor: query.cursor,
+        limit: query.limit,
+        category: query.category
+          ? categoryMap.decode(query.category)
+          : undefined,
+        responded: query.responded,
+        orderBy: query.orderBy,
+        orderDirection: query.orderDirection,
+      });
+
+    return {
+      success: true,
+      data: {
+        items: items.map((counsel) => ({
+          id: counsel.id,
+          title: counsel.title,
+          category: categoryMap.encode(counsel.category),
+          createdAt: counsel.createdAt,
+          responded: counsel.responseContent !== null,
+        })),
+        nextCursor: nextCursor ?? null,
+      },
+    };
+  }
+
+  @Get(":id")
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(GetCounselResponseDtoSchema)
+  async getCounsel(
+    @ZodParam("id", idParamSchema) id: number,
+  ): Promise<GetCounselSuccessResponseDto> {
+    const entry = await this.counselQueryService.getCounselEntry(id);
+    return {
+      success: true,
+      data: {
+        id: entry.id,
+        title: entry.title,
+        content: entry.content,
+        category: categoryMap.encode(entry.category),
+        createdAt: entry.createdAt,
+        response: entry.responseContent ?? undefined,
+      },
+    };
+  }
+
+  @Put(":id")
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(UpdateCounselResponseDtoSchema)
+  async updateCounsel(
+    @CurrentUser() user: User,
+    @ZodParam("id", idParamSchema) id: number,
+    @ZodBody(UpdateCounselRequestDtoSchema) body: UpdateCounselRequestDto,
+  ): Promise<UpdateCounselSuccessResponseDto> {
+    await this.counselMutationService.updateCounselEntry({
+      id,
+      userId: user.id,
+      title: body.title,
+      content: body.content,
+      category: categoryMap.decode(body.category),
+    });
+    return { success: true, data: null };
+  }
+
+  @Delete(":id")
+  @HttpCode(HttpStatus.OK)
+  @UserOnly()
+  @ZodEncodeResponse(DeleteCounselResponseDtoSchema)
+  async deleteCounsel(
+    @CurrentUser() user: User,
+    @ZodParam("id", idParamSchema) id: number,
+  ): Promise<DeleteCounselSuccessResponseDto> {
+    await this.counselMutationService.deleteCounselEntry(id, user.id);
+    return { success: true, data: null };
+  }
+}

--- a/apps/backend/src/counsel/counsel.errors.ts
+++ b/apps/backend/src/counsel/counsel.errors.ts
@@ -1,0 +1,23 @@
+import { HttpStatus } from "@nestjs/common";
+import { ServiceError } from "src/common/errors/service.error";
+import { CounselErrorCode } from "@mindseed/api-types";
+
+export class CounselServiceError extends ServiceError {}
+
+export class CounselNotFoundError extends CounselServiceError {
+  constructor() {
+    super(HttpStatus.NOT_FOUND, CounselErrorCode.COUNSEL_NOT_FOUND);
+  }
+}
+
+export class NotCounselAuthorError extends CounselServiceError {
+  constructor() {
+    super(HttpStatus.FORBIDDEN, CounselErrorCode.NOT_COUNSEL_AUTHOR);
+  }
+}
+
+export class CounselAlreadyRespondedError extends CounselServiceError {
+  constructor() {
+    super(HttpStatus.CONFLICT, CounselErrorCode.COUNSEL_ALREADY_RESPONDED);
+  }
+}

--- a/apps/backend/src/counsel/counsel.mappers.ts
+++ b/apps/backend/src/counsel/counsel.mappers.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { CounselCategorySchema } from "@mindseed/api-types";
+import { CounselCategory } from "./entities/counsel-entry.entity";
+import { createBiMap } from "src/common/helpers/mapper";
+
+type ApiCounselCategory = z.output<typeof CounselCategorySchema>;
+
+export const categoryMap = createBiMap<CounselCategory, ApiCounselCategory>([
+  [CounselCategory.ANXIETY, "anxiety"],
+  [CounselCategory.DEPRESSION, "depression"],
+  [CounselCategory.STRESS, "stress"],
+  [CounselCategory.OTHER, "other"],
+]);

--- a/apps/backend/src/counsel/counsel.module.ts
+++ b/apps/backend/src/counsel/counsel.module.ts
@@ -1,0 +1,4 @@
+import { Module } from "@nestjs/common";
+
+@Module({})
+export class CounselModule {}

--- a/apps/backend/src/counsel/counsel.module.ts
+++ b/apps/backend/src/counsel/counsel.module.ts
@@ -1,4 +1,10 @@
 import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { CounselEntry } from "./entities/counsel-entry.entity";
+import { CounselQueryService } from "./counsel-query.service";
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([CounselEntry])],
+  providers: [CounselQueryService],
+})
 export class CounselModule {}

--- a/apps/backend/src/counsel/counsel.module.ts
+++ b/apps/backend/src/counsel/counsel.module.ts
@@ -2,9 +2,15 @@ import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { CounselEntry } from "./entities/counsel-entry.entity";
 import { CounselQueryService } from "./counsel-query.service";
+import { CounselMutationService } from "./counsel-mutation.service";
+import { CounselController } from "./counsel.controller";
+import { CounselAdminController } from "./counsel-admin.controller";
+import { AuthModule } from "src/auth/auth.module";
+import { UserModule } from "src/user/user.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CounselEntry])],
-  providers: [CounselQueryService],
+  imports: [TypeOrmModule.forFeature([CounselEntry]), AuthModule, UserModule],
+  controllers: [CounselController, CounselAdminController],
+  providers: [CounselQueryService, CounselMutationService],
 })
 export class CounselModule {}

--- a/apps/backend/src/counsel/entities/counsel-entry.entity.ts
+++ b/apps/backend/src/counsel/entities/counsel-entry.entity.ts
@@ -46,7 +46,7 @@ export class CounselEntry {
   @UpdateTimestampColumn()
   updatedAt: Temporal.Instant;
 
-  @Column()
+  @Column({ nullable: true })
   responderId: number | null;
 
   // 2026-04-16 onDelete option을 지정하지 않았습니다. 현재는 ADMIN user는
@@ -57,6 +57,6 @@ export class CounselEntry {
   @JoinColumn()
   responder: User | null;
 
-  @Column({ type: "text" })
+  @Column({ type: "text", nullable: true })
   responseContent: string | null;
 }

--- a/apps/backend/src/counsel/entities/counsel-entry.entity.ts
+++ b/apps/backend/src/counsel/entities/counsel-entry.entity.ts
@@ -1,0 +1,62 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import { Temporal } from "@js-temporal/polyfill";
+import {
+  CreateTimestampColumn,
+  UpdateTimestampColumn,
+} from "src/database/decorators/temporal.decorators";
+import { User } from "src/user/entities/user.entity";
+
+export enum CounselCategory {
+  ANXIETY = "ANXIETY",
+  DEPRESSION = "DEPRESSION",
+  STRESS = "STRESS",
+  OTHER = "OTHER",
+}
+
+@Entity({ name: "counsel" })
+export class CounselEntry {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column({ type: "text" })
+  content: string;
+
+  @Column({ type: "enum", enum: CounselCategory })
+  category: CounselCategory;
+
+  @Column()
+  authorId: number;
+
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn()
+  author: User;
+
+  @CreateTimestampColumn()
+  createdAt: Temporal.Instant;
+
+  @UpdateTimestampColumn()
+  updatedAt: Temporal.Instant;
+
+  @Column()
+  responderId: number | null;
+
+  // 2026-04-16 onDelete option을 지정하지 않았습니다. 현재는 ADMIN user는
+  // 회원탈퇴를 하지 않을 것이라고 가정하고 있으며, CASCADE로 설정 시
+  // responseContent 처리가 애매해짐을 근거로 하였습니다. 추후 문제가 될 경우
+  // response entity를 분리하는 방식으로 처리해야 할 듯 합니다.
+  @ManyToOne(() => User)
+  @JoinColumn()
+  responder: User | null;
+
+  @Column({ type: "text" })
+  responseContent: string | null;
+}

--- a/apps/backend/src/database/database.module.ts
+++ b/apps/backend/src/database/database.module.ts
@@ -14,6 +14,7 @@ import { Mission } from "src/mission/entities/mission.entity";
 import { MissionAssignment } from "src/mission/entities/mission-assignment.entity";
 import { DiagnosisEntry } from "src/diagnosis/entities/diagnosis-entry.entity";
 import { SnakeNamingStrategy } from "typeorm-naming-strategies";
+import { CounselEntry } from "src/counsel/entities/counsel-entry.entity";
 
 @Module({
   imports: [
@@ -28,16 +29,17 @@ import { SnakeNamingStrategy } from "typeorm-naming-strategies";
         database: db.database,
         entities: [
           Attachment,
-          User,
-          UserProfile,
-          RefreshToken,
+          CounselEntry,
+          DiagnosisEntry,
+          Mission,
+          MissionAssignment,
           Post,
           PostComment,
           PostLike,
+          RefreshToken,
           Resource,
-          Mission,
-          MissionAssignment,
-          DiagnosisEntry,
+          User,
+          UserProfile,
         ],
         synchronize: process.env.NODE_ENV !== "production",
         namingStrategy: new SnakeNamingStrategy(),

--- a/apps/backend/src/post/post-query.service.spec.ts
+++ b/apps/backend/src/post/post-query.service.spec.ts
@@ -291,7 +291,7 @@ describe("PostQueryService", () => {
       });
 
       // Then: throws handled error
-      expect(result).rejects.toThrow(InvalidCursorError);
+      await expect(result).rejects.toThrow(InvalidCursorError);
     });
   });
 

--- a/apps/backend/src/post/post-query.service.spec.ts
+++ b/apps/backend/src/post/post-query.service.spec.ts
@@ -176,34 +176,6 @@ describe("PostQueryService", () => {
         // Then: 삭제된 글 다음부터 올바르게 반환
         expect(result.items.map((p) => p.post.id)).toEqual([ids[1], ids[2]]);
       });
-
-      it("category 및 orderBy와 벗어난 cursor 처리", async () => {
-        // Given: cursor가 category 및 orderBy를 다르게 하여 조회했을 때의
-        // 결과물인 경우
-        const user = await saveTestUser();
-        await saveTestPosts(user.id, [
-          { category: PostCategory.DUMMY1 },
-          { category: PostCategory.DUMMY1 },
-        ]);
-        const firstPage = await postQueryService.listPosts(user.id, {
-          limit: 1,
-          orderBy: "createdAt",
-          orderDirection: "asc",
-          category: PostCategory.DUMMY1,
-        });
-
-        // When: 글 조회 시도
-        const result = postQueryService.listPosts(user.id, {
-          cursor: firstPage.nextCursor,
-          limit: 1,
-          orderBy: "createdAt",
-          orderDirection: "asc",
-          category: PostCategory.DUMMY2,
-        });
-
-        // Then: throws handled error
-        await expect(result).rejects.toThrow(InvalidCursorError);
-      });
     });
 
     describe("relation fields", () => {
@@ -303,6 +275,23 @@ describe("PostQueryService", () => {
       expect(result.attachmentToUrl[attachment.id]).toBe(
         fakeS3.getPublicUrl(attachment.s3Key),
       );
+    });
+
+    it("올바르지 않은 형식의 cursor인 경우 처리", async () => {
+      // Given: 올바르지 않은 형식의 cursor
+      const user = await saveTestUser();
+      const malformedCursor = "arst";
+
+      // When: 글 목록 조회 시도
+      const result = postQueryService.listPosts(user.id, {
+        limit: 1,
+        orderBy: "createdAt",
+        orderDirection: "asc",
+        cursor: malformedCursor,
+      });
+
+      // Then: throws handled error
+      expect(result).rejects.toThrow(InvalidCursorError);
     });
   });
 

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -10,8 +10,7 @@ import {
   CursorPaginationOptions,
   CursorPaginationResult,
 } from "src/common/helpers/pagination";
-import { createCursorCodec } from "src/common/helpers/cursor";
-import z from "zod";
+import { executeCursorPagination } from "src/common/helpers/cursor";
 
 /* shared types */
 
@@ -37,13 +36,6 @@ export type ListPostsResult = CursorPaginationResult<PostWithRelations> & {
   attachmentToUrl: AttachmentToUrlMap;
 };
 
-const cursorCodec = createCursorCodec(
-  z.object({
-    value: z.string(),
-    id: z.number(),
-  }),
-);
-
 /* getPost */
 
 export type GetPostResult = {
@@ -51,23 +43,14 @@ export type GetPostResult = {
   attachmentToUrl: AttachmentToUrlMap;
 };
 
-// 2026-03-25 code smell....
-const orderByMap: Record<
-  ListPostsOrderBy,
-  {
-    path: string;
-    column: string;
-    cast: string;
-    getValue: (post: Post) => string;
-  }
-> = {
+const orderByMap = {
   createdAt: {
-    path: "post.createdAt",
-    column: "extract(epoch FROM post.createdAt)::int",
-    cast: "extract(epoch FROM :cursorValue::timestamp)::int",
-    getValue: (post) => post.createdAt.toString(),
+    sqlPath: "post.createdAt",
+    sqlCursorValue: "extract(epoch FROM post.createdAt)::int",
+    toCursorValue: (post: Post) =>
+      Math.floor(post.createdAt.epochMilliseconds / 1000),
   },
-};
+} satisfies Record<ListPostsOrderBy, object>;
 
 /**
  * controller에서 사용하기 위한 글의 조회를 담당한다.
@@ -90,12 +73,6 @@ export class PostQueryService {
     userId: number,
     { limit, orderBy, orderDirection, category, cursor }: ListPostsOptions,
   ): Promise<ListPostsResult> {
-    const decodedCursor = cursor && cursorCodec.decode(cursor);
-
-    const sqlDirection = orderDirection === "asc" ? "ASC" : "DESC";
-    const cursorOp = orderDirection === "asc" ? ">" : "<";
-    const orderEntry = orderByMap[orderBy];
-
     const qb = this.postRepository
       .createQueryBuilder("post")
       .leftJoinAndSelect("post.author", "author")
@@ -105,25 +82,12 @@ export class PostQueryService {
       qb.where("post.category = :category", { category });
     }
 
-    if (decodedCursor) {
-      qb.andWhere(
-        [
-          `(${orderEntry.column}, "post"."id")`,
-          cursorOp,
-          `(${orderEntry.cast}, :cursorId::int)`,
-        ].join(""),
-        {
-          cursorValue: decodedCursor.value,
-          cursorId: decodedCursor.id,
-        },
-      );
-    }
-
-    const posts = await qb
-      .orderBy(orderEntry.path, sqlDirection)
-      .addOrderBy("post.id", sqlDirection)
-      .take(limit + 1)
-      .getMany();
+    const { items: posts, nextCursor } = await executeCursorPagination(qb, {
+      cursor,
+      orderByField: orderByMap[orderBy],
+      orderDirection,
+      limit,
+    });
 
     const postIds = posts.map((p) => p.id);
     const likedPostIds = new Set(
@@ -142,23 +106,15 @@ export class PostQueryService {
     const attachments = posts.flatMap((p) => p.attachments);
     const attachmentToUrl = this.buildAttachmentToUrl(attachments);
 
-    const resultPosts = posts.slice(0, limit);
-    const lastPost = resultPosts.at(-1);
     return {
-      items: resultPosts.map((post) => ({
+      items: posts.map((post) => ({
         post,
         withUser: {
           isOwner: post.authorId === userId,
           isLiked: likedPostIds.has(post.id),
         },
       })),
-      nextCursor:
-        posts.length > limit && lastPost
-          ? cursorCodec.encode({
-              id: lastPost.id,
-              value: orderEntry.getValue(lastPost),
-            })
-          : undefined,
+      nextCursor,
       attachmentToUrl,
     };
   }

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -6,11 +6,12 @@ import { PostLike } from "./entities/post-like.entity";
 import { Attachment } from "../attachment/entities/attachment.entity";
 import { S3StorageService } from "src/s3-storage/s3-storage.service";
 import { PostNotFoundError } from "./post.errors";
-import { InvalidCursorError } from "src/common/errors/pagination.errors";
 import {
   CursorPaginationOptions,
   CursorPaginationResult,
 } from "src/common/helpers/pagination";
+import { createCursorCodec } from "src/common/helpers/cursor";
+import z from "zod";
 
 /* shared types */
 
@@ -28,14 +29,20 @@ export type AttachmentToUrlMap = Record<number, string>;
 
 export type ListPostsOrderBy = "createdAt";
 
-export type ListPostsPaginationOptions =
-  CursorPaginationOptions<ListPostsOrderBy> & {
-    category?: PostCategory;
-  };
+export type ListPostsOptions = CursorPaginationOptions<ListPostsOrderBy> & {
+  category?: PostCategory;
+};
 
 export type ListPostsResult = CursorPaginationResult<PostWithRelations> & {
   attachmentToUrl: AttachmentToUrlMap;
 };
+
+const cursorCodec = createCursorCodec(
+  z.object({
+    value: z.string(),
+    id: z.number(),
+  }),
+);
 
 /* getPost */
 
@@ -43,27 +50,6 @@ export type GetPostResult = {
   entry: PostWithRelations;
   attachmentToUrl: AttachmentToUrlMap;
 };
-
-type CursorPayload = {
-  category: PostCategory | null;
-  orderBy: ListPostsOrderBy;
-  orderDirection: "asc" | "desc";
-  cursorValue: string;
-  cursorId: number;
-};
-
-function encodeCursor(payload: CursorPayload): string {
-  return Buffer.from(JSON.stringify(payload)).toString("base64url");
-}
-
-// FIXME: structural validation for cursor value
-function decodeCursor(cursor: string): CursorPayload {
-  try {
-    return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
-  } catch {
-    throw new InvalidCursorError();
-  }
-}
 
 // 2026-03-25 code smell....
 const orderByMap: Record<
@@ -102,24 +88,9 @@ export class PostQueryService {
    */
   async listPosts(
     userId: number,
-    {
-      limit,
-      orderBy,
-      orderDirection,
-      category,
-      cursor,
-    }: ListPostsPaginationOptions,
+    { limit, orderBy, orderDirection, category, cursor }: ListPostsOptions,
   ): Promise<ListPostsResult> {
-    const decodedCursor = cursor && decodeCursor(cursor);
-
-    if (
-      decodedCursor &&
-      (category != decodedCursor.category || // != for null-undefined checks
-        orderBy !== decodedCursor.orderBy ||
-        orderDirection !== decodedCursor.orderDirection)
-    ) {
-      throw new InvalidCursorError();
-    }
+    const decodedCursor = cursor && cursorCodec.decode(cursor);
 
     const sqlDirection = orderDirection === "asc" ? "ASC" : "DESC";
     const cursorOp = orderDirection === "asc" ? ">" : "<";
@@ -142,8 +113,8 @@ export class PostQueryService {
           `(${orderEntry.cast}, :cursorId::int)`,
         ].join(""),
         {
-          cursorValue: decodedCursor.cursorValue,
-          cursorId: decodedCursor.cursorId,
+          cursorValue: decodedCursor.value,
+          cursorId: decodedCursor.id,
         },
       );
     }
@@ -183,12 +154,9 @@ export class PostQueryService {
       })),
       nextCursor:
         posts.length > limit && lastPost
-          ? encodeCursor({
-              orderBy,
-              orderDirection,
-              category: category ?? null,
-              cursorId: lastPost.id,
-              cursorValue: orderEntry.getValue(lastPost),
+          ? cursorCodec.encode({
+              id: lastPost.id,
+              value: orderEntry.getValue(lastPost),
             })
           : undefined,
       attachmentToUrl,

--- a/apps/backend/src/resource/resource-query.service.spec.ts
+++ b/apps/backend/src/resource/resource-query.service.spec.ts
@@ -184,7 +184,7 @@ describe("ResourceQueryService", () => {
       });
 
       // Then: throws handled error
-      expect(result).rejects.toThrow(InvalidCursorError);
+      await expect(result).rejects.toThrow(InvalidCursorError);
     });
   });
 });

--- a/apps/backend/src/resource/resource-query.service.spec.ts
+++ b/apps/backend/src/resource/resource-query.service.spec.ts
@@ -171,31 +171,20 @@ describe("ResourceQueryService", () => {
       expect(result.items.map((r) => r.id)).toEqual([ids[1], ids[2]]);
     });
 
-    it("category 및 orderBy와 벗어난 cursor 처리", async () => {
-      // Given: cursor가 category 및 orderBy를 다르게 하여 조회했을 때의
-      // 결과물인 경우
-      await saveTestResources([
-        { category: ResourceCategory.DUMMY1 },
-        { category: ResourceCategory.DUMMY1 },
-      ]);
-      const firstPage = await resourceQueryService.listResourcesWithCursor({
-        limit: 1,
-        orderBy: "createdAt",
-        orderDirection: "asc",
-        category: ResourceCategory.DUMMY1,
-      });
+    it("올바르지 않은 형식의 cursor인 경우 처리", async () => {
+      // Given: 올바르지 않은 형식의 cursor
+      const malformedCursor = "arst";
 
       // When: 조회 시도
       const result = resourceQueryService.listResourcesWithCursor({
-        cursor: firstPage.nextCursor,
+        cursor: malformedCursor,
         limit: 1,
         orderBy: "createdAt",
         orderDirection: "asc",
-        category: ResourceCategory.DUMMY2,
       });
 
       // Then: throws handled error
-      await expect(result).rejects.toThrow(InvalidCursorError);
+      expect(result).rejects.toThrow(InvalidCursorError);
     });
   });
 });

--- a/apps/backend/src/resource/resource-query.service.ts
+++ b/apps/backend/src/resource/resource-query.service.ts
@@ -9,6 +9,8 @@ import {
   OffsetPaginationOptions,
   OffsetPaginationResult,
 } from "src/common/helpers/pagination";
+import { createCursorCodec } from "src/common/helpers/cursor";
+import z from "zod";
 
 export type ListResourcesOrderBy = "createdAt";
 
@@ -26,25 +28,12 @@ export type ListResourcesWithCursorOptions =
 
 export type ListResourcesWithCursorResult = CursorPaginationResult<Resource>;
 
-type CursorPayload = {
-  category: ResourceCategory | null;
-  orderBy: ListResourcesOrderBy;
-  orderDirection: "asc" | "desc";
-  cursorValue: string;
-  cursorId: number;
-};
-
-function encodeCursor(payload: CursorPayload): string {
-  return Buffer.from(JSON.stringify(payload)).toString("base64url");
-}
-
-function decodeCursor(cursor: string): CursorPayload {
-  try {
-    return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
-  } catch {
-    throw new InvalidCursorError();
-  }
-}
+const cursorCodec = createCursorCodec(
+  z.object({
+    value: z.string(),
+    id: z.number(),
+  }),
+);
 
 const orderByMap: Record<
   ListResourcesOrderBy,
@@ -117,16 +106,7 @@ export class ResourceQueryService {
     orderBy,
     orderDirection,
   }: ListResourcesWithCursorOptions): Promise<ListResourcesWithCursorResult> {
-    const decodedCursor = cursor && decodeCursor(cursor);
-
-    if (
-      decodedCursor &&
-      ((category ?? null) !== decodedCursor.category ||
-        orderBy !== decodedCursor.orderBy ||
-        orderDirection !== decodedCursor.orderDirection)
-    ) {
-      throw new InvalidCursorError();
-    }
+    const decodedCursor = cursor && cursorCodec.decode(cursor);
 
     const qb = this.resourceRepository.createQueryBuilder("resource");
 
@@ -145,8 +125,8 @@ export class ResourceQueryService {
           `(${orderEntry.cast}, :cursorId::int)`,
         ].join(""),
         {
-          cursorValue: decodedCursor.cursorValue,
-          cursorId: decodedCursor.cursorId,
+          cursorValue: decodedCursor.value,
+          cursorId: decodedCursor.id,
         },
       );
     }
@@ -165,12 +145,9 @@ export class ResourceQueryService {
       items: resultItems,
       nextCursor:
         items.length > limit && lastItem
-          ? encodeCursor({
-              orderBy,
-              orderDirection,
-              category: category ?? null,
-              cursorId: lastItem.id,
-              cursorValue: orderEntry.getValue(lastItem),
+          ? cursorCodec.encode({
+              id: lastItem.id,
+              value: orderEntry.getValue(lastItem),
             })
           : undefined,
     };

--- a/apps/backend/src/resource/resource-query.service.ts
+++ b/apps/backend/src/resource/resource-query.service.ts
@@ -2,15 +2,13 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Resource, ResourceCategory } from "./entities/resource.entity";
-import { InvalidCursorError } from "src/common/errors/pagination.errors";
 import {
   CursorPaginationOptions,
   CursorPaginationResult,
   OffsetPaginationOptions,
   OffsetPaginationResult,
 } from "src/common/helpers/pagination";
-import { createCursorCodec } from "src/common/helpers/cursor";
-import z from "zod";
+import { executeCursorPagination } from "src/common/helpers/cursor";
 
 export type ListResourcesOrderBy = "createdAt";
 
@@ -28,29 +26,14 @@ export type ListResourcesWithCursorOptions =
 
 export type ListResourcesWithCursorResult = CursorPaginationResult<Resource>;
 
-const cursorCodec = createCursorCodec(
-  z.object({
-    value: z.string(),
-    id: z.number(),
-  }),
-);
-
-const orderByMap: Record<
-  ListResourcesOrderBy,
-  {
-    path: string;
-    column: string;
-    cast: string;
-    getValue: (resource: Resource) => string;
-  }
-> = {
+const orderByMap = {
   createdAt: {
-    path: "resource.createdAt",
-    column: "extract(epoch FROM resource.createdAt)::int",
-    cast: "extract(epoch FROM :cursorValue::timestamp)::int",
-    getValue: (resource) => resource.createdAt.toString(),
+    sqlPath: "resource.createdAt",
+    sqlCursorValue: "extract(epoch FROM resource.createdAt)::int",
+    toCursorValue: (resource: Resource) =>
+      Math.floor(resource.createdAt.epochMilliseconds / 1000),
   },
-};
+} satisfies Record<ListResourcesOrderBy, object>;
 
 /**
  * AdminResourceController에서 사용하기 위한 resource의 조회를 담당한다.
@@ -82,7 +65,7 @@ export class ResourceQueryService {
     const sqlDirection = orderDirection === "asc" ? "ASC" : "DESC";
 
     const items = await qb
-      .orderBy(orderEntry.path, sqlDirection)
+      .orderBy(orderEntry.sqlPath, sqlDirection)
       .addOrderBy("resource.id", sqlDirection)
       .skip(offset)
       .take(limit + 1)
@@ -106,50 +89,17 @@ export class ResourceQueryService {
     orderBy,
     orderDirection,
   }: ListResourcesWithCursorOptions): Promise<ListResourcesWithCursorResult> {
-    const decodedCursor = cursor && cursorCodec.decode(cursor);
-
     const qb = this.resourceRepository.createQueryBuilder("resource");
 
     if (category) {
       qb.where("resource.category = :category", { category });
     }
 
-    const cursorOp = orderDirection === "asc" ? ">" : "<";
-    const orderEntry = orderByMap[orderBy];
-
-    if (decodedCursor) {
-      qb.andWhere(
-        [
-          `(${orderEntry.column}, "resource"."id")`,
-          cursorOp,
-          `(${orderEntry.cast}, :cursorId::int)`,
-        ].join(""),
-        {
-          cursorValue: decodedCursor.value,
-          cursorId: decodedCursor.id,
-        },
-      );
-    }
-
-    const sqlDirection = orderDirection === "asc" ? "ASC" : "DESC";
-
-    const items = await qb
-      .orderBy(orderEntry.path, sqlDirection)
-      .addOrderBy("resource.id", sqlDirection)
-      .take(limit + 1)
-      .getMany();
-
-    const resultItems = items.slice(0, limit);
-    const lastItem = resultItems.at(-1);
-    return {
-      items: resultItems,
-      nextCursor:
-        items.length > limit && lastItem
-          ? cursorCodec.encode({
-              id: lastItem.id,
-              value: orderEntry.getValue(lastItem),
-            })
-          : undefined,
-    };
+    return executeCursorPagination(qb, {
+      cursor,
+      orderByField: orderByMap[orderBy],
+      orderDirection,
+      limit,
+    });
   }
 }


### PR DESCRIPTION
## 요약

- Closes #112 
- 익명 심리 상담 기능의 백엔드 구현을 작성하였습니다.

## 내용 (`backend`)

- `CounselEntry`, `CounselMutationService`, `CounselQueryService`, `CounselController`, `CounselAdminController`를 작성하였습니다.
- refactoring: 중복되는 cursor navigation logic을 helper method로 분리하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added counseling module enabling users to create, read, update, and delete counsel entries
  * Added support for categorizing counsel entries (anxiety, depression, stress, and others)
  * Added admin interface for managing counsel submissions and providing responses
  * Improved pagination performance across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->