### PR TITLE
TypeORM temporal transformer의 operator 처리 수정

### DIFF
--- a/apps/backend/src/auth/refresh-token/refresh-token.service.ts
+++ b/apps/backend/src/auth/refresh-token/refresh-token.service.ts
@@ -68,7 +68,7 @@ export class RefreshTokenService {
   @Cron(CronExpression.EVERY_HOUR)
   async deleteExpired(): Promise<void> {
     await this.refreshTokenRepository.delete({
-      expiresAt: LessThan(new Date()),
+      expiresAt: LessThan(Temporal.Now.instant()),
     });
   }
 

--- a/apps/backend/src/database/decorators/temporal.decorators.ts
+++ b/apps/backend/src/database/decorators/temporal.decorators.ts
@@ -11,18 +11,17 @@ import {
  * Entity들에서는 timestampz 타입만 사용한다는 전제하에 작성되었습니다.
  */
 
+// 2026-05-08 transformer는 arbritrary value를 받을 수 있으며, query 시의
+// operator (Not 등) 도 이에 해당합니다. 따라서 primitive 만 받을 것이라고
+// 가정해서는 안 됩니다
 const temporalInstantTransformer = {
-  to: (
-    instant: Temporal.Instant | null | undefined,
-  ): Date | null | undefined => {
-    return instant != null
+  to: (instant: unknown) => {
+    return instant instanceof Temporal.Instant
       ? new Date(Number(instant.epochMilliseconds))
       : instant;
   },
-  from: (
-    instant: Date | string | null | undefined,
-  ): Temporal.Instant | null | undefined => {
-    return instant != null
+  from: (instant: unknown) => {
+    return instant instanceof Date || typeof instant === "string"
       ? Temporal.Instant.fromEpochMilliseconds(new Date(instant).getTime())
       : instant;
   },


### PR DESCRIPTION
## 문제 상황

TypeORM에서, Temporal 타입 값들을 처리하기 위해 custom transformer가 각 column에 사용됩니다. 이때 transformer에 단순 value가 아닌 operator 형태의 값이 넘겨질 경우 올바른 변환이 일어나지 않아 query가 실패하는 경우가 발생합니다.

## 수정사항

transformation의 조건을 변경하여 query가 올바르게 작동하도록 하였습니다.