### PR TITLE
Feature/#138

### DIFF
--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -5,3 +5,6 @@
 # Tests
 /coverage
 /.nyc_output
+
+# Local API smoke test page
+/s3-smoke-test.html

--- a/apps/backend/src/database/database.module.ts
+++ b/apps/backend/src/database/database.module.ts
@@ -16,6 +16,7 @@ import { DiagnosisEntry } from "src/diagnosis/entities/diagnosis-entry.entity";
 import { SnakeNamingStrategy } from "typeorm-naming-strategies";
 import { CounselEntry } from "src/counsel/entities/counsel-entry.entity";
 import { Report } from "src/report/entities/report.entity";
+import { S3Queue } from "src/s3-storage/entities/s3-queue";
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { Report } from "src/report/entities/report.entity";
           PostLike,
           RefreshToken,
           Resource,
+          S3Queue,
           User,
           UserProfile,
           Report,

--- a/apps/backend/src/post/post-mutation.service.spec.ts
+++ b/apps/backend/src/post/post-mutation.service.spec.ts
@@ -539,4 +539,66 @@ describe("PostMutationService", () => {
       await expect(result).rejects.toThrow(NotPostAuthorError);
     });
   });
+
+  describe("deleteAdminPost", () => {
+    it("success: 글 및 attachment 삭제", async () => {
+      // Given: 글이 존재하는 경우
+      const user = await saveTestUser();
+      const post = await saveTestPost(user.id);
+      const attachment = await saveTestAttachment({ post });
+      fakeS3.put(attachment.s3Key);
+
+      // When: admin이 글 삭제 시도
+      await postMutationService.deleteAdminPost(post.id);
+
+      // Then: 글 및 attachments 삭제됨
+      expect(await postRepository.findOneBy({ id: post.id })).toBeNull();
+      expect(
+        await attachmentRepository.findOneBy({ id: attachment.id }),
+      ).toBeNull();
+      expect(await fakeS3.exists(attachment.s3Key)).toBe(false);
+    });
+
+    it("다른 사용자의 글도 삭제 가능", async () => {
+      // Given: 다른 사용자의 글이 존재하는 경우
+      const author = await saveTestUser();
+      const otherUser = await saveTestUser();
+      const post = await saveTestPost(author.id);
+      const attachment = await saveTestAttachment({ post });
+      fakeS3.put(attachment.s3Key);
+
+      // When: 다른 사용자가 admin 권한으로 글 삭제 시도
+      await postMutationService.deleteAdminPost(post.id);
+
+      // Then: 글 및 attachments 삭제됨
+      expect(await postRepository.findOneBy({ id: post.id })).toBeNull();
+      expect(
+        await attachmentRepository.findOneBy({ id: attachment.id }),
+      ).toBeNull();
+      expect(await fakeS3.exists(attachment.s3Key)).toBe(false);
+    });
+
+    it("존재하지 않는 글 처리", async () => {
+      // Given: 글이 존재하지 않는 경우
+
+      // When: admin이 글 삭제 시도
+      const result = postMutationService.deleteAdminPost(0);
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(PostNotFoundError);
+    });
+
+    it("탈퇴한 글 owner 처리 (soft-deleted)", async () => {
+      // Given: 탈퇴된 owner의 글인 경우
+      const author = await saveTestUser();
+      const post = await saveTestPost(author.id);
+      await userRepository.softDelete({ id: author.id });
+
+      // When: admin이 글 삭제 시도
+      const result = postMutationService.deleteAdminPost(post.id);
+
+      // Then: throws handled error
+      await expect(result).rejects.toThrow(PostNotFoundError);
+    });
+  });
 });

--- a/apps/backend/src/post/post-mutation.service.ts
+++ b/apps/backend/src/post/post-mutation.service.ts
@@ -200,6 +200,28 @@ export class PostMutationService {
   }
 
   /**
+   * Admin 전용으로, 어뜬 글이든 삭제한다.
+   */
+  async deleteAdminPost(postId: number): Promise<void> {
+    const post = await this.postRepository.findOne({
+      where: { id: postId },
+      relations: { attachments: true, author: true },
+    });
+
+    if (!post || !post.isActive()) {
+      throw new PostNotFoundError();
+    }
+
+    await this.postRepository.delete({
+      id: postId,
+    });
+
+    await this.s3StorageService.deleteMany(
+      post.attachments.map((a) => a.s3Key),
+    );
+  }
+
+  /**
    * attachmentIds가 가리키는 attachment가 모두 글과 연관될 수 있는지를
    * 확인한다.
    * 존재하지 않는 경우 / confirmed 되지 않은 경우 / 이미 다른 글과 연관되어 있으면

--- a/apps/backend/src/post/post-mutation.service.ts
+++ b/apps/backend/src/post/post-mutation.service.ts
@@ -200,7 +200,7 @@ export class PostMutationService {
   }
 
   /**
-   * Admin 전용으로, 어뜬 글이든 삭제한다.
+   * Admin 전용으로, 어떤 글이든 삭제한다.
    */
   async deleteAdminPost(postId: number): Promise<void> {
     const post = await this.postRepository.findOne({

--- a/apps/backend/src/post/post-query.service.spec.ts
+++ b/apps/backend/src/post/post-query.service.spec.ts
@@ -123,11 +123,15 @@ describe("PostQueryService", () => {
           provide: getRepositoryToken(PostComment),
           useValue: dataSource.getRepository(PostComment),
         },
-        { provide: S3StorageService, useValue: fakeS3 },
         {
           provide: getRepositoryToken(Report),
           useValue: dataSource.getRepository(Report),
         },
+        {
+          provide: getRepositoryToken(Attachment),
+          useValue: dataSource.getRepository(Attachment),
+        },
+        { provide: S3StorageService, useValue: fakeS3 },
       ],
     }).compile();
 

--- a/apps/backend/src/post/post-query.service.spec.ts
+++ b/apps/backend/src/post/post-query.service.spec.ts
@@ -453,6 +453,110 @@ describe("PostQueryService", () => {
     });
   });
 
+  describe("adminListPosts", () => {
+    async function saveReport(postId: number, userId: number) {
+      return reportRepository.save(
+        reportRepository.create({
+          reason: "신고",
+          range: ReportRange.POST,
+          post: { id: postId } as Post,
+          user: { id: userId } as User,
+        }),
+      );
+    }
+
+    it("success: latest 정렬과 page/limit 페이지네이션", async () => {
+      const user = await saveTestUser();
+      const ids = await saveTestPosts(user.id, [{}, {}, {}]);
+
+      const result = await postQueryService.adminListPosts({
+        page: 1,
+        limit: 2,
+        orderBy: "latest",
+        isReported: false,
+      });
+
+      expect(result.items.map((p) => p.post.id)).toEqual([ids[2], ids[1]]);
+      expect(result.totalCount).toBe(3);
+    });
+
+    it("success: oldest 정렬의 2페이지 반환", async () => {
+      const user = await saveTestUser();
+      const ids = await saveTestPosts(user.id, [{}, {}, {}]);
+
+      const result = await postQueryService.adminListPosts({
+        page: 2,
+        limit: 2,
+        orderBy: "oldest",
+        isReported: false,
+      });
+
+      expect(result.items.map((p) => p.post.id)).toEqual([ids[2]]);
+      expect(result.totalCount).toBe(3);
+    });
+
+    it("success: mostReported 정렬과 신고 수 반환", async () => {
+      const author = await saveTestUser();
+      const reporter1 = await saveTestUser();
+      const reporter2 = await saveTestUser();
+      const ids = await saveTestPosts(author.id, [{}, {}, {}]);
+      await saveReport(ids[0], reporter1.id);
+      await saveReport(ids[2], reporter1.id);
+      await saveReport(ids[2], reporter2.id);
+
+      const result = await postQueryService.adminListPosts({
+        page: 1,
+        limit: 10,
+        orderBy: "mostReported",
+        isReported: false,
+      });
+
+      expect(result.items.map((p) => p.post.id)).toEqual([
+        ids[2],
+        ids[0],
+        ids[1],
+      ]);
+      expect(result.items.map((p) => p.additional.reportCount)).toEqual([
+        2, 1, 0,
+      ]);
+      expect(result.totalCount).toBe(3);
+    });
+
+    it("success: category, isReported, query 필터와 totalCount", async () => {
+      const author = await saveTestUser();
+      const reporter = await saveTestUser();
+      const [post1, post2, post3] = await Promise.all([
+        saveTestPost(author.id, {
+          content: "alpha content",
+          category: PostCategory.DUMMY1,
+        }),
+        saveTestPost(author.id, {
+          content: "beta content",
+          category: PostCategory.DUMMY1,
+        }),
+        saveTestPost(author.id, {
+          content: "alpha hidden",
+          category: PostCategory.DUMMY2,
+        }),
+      ]);
+      await saveReport(post1.id, reporter.id);
+      await saveReport(post3.id, reporter.id);
+
+      const result = await postQueryService.adminListPosts({
+        page: 1,
+        limit: 10,
+        orderBy: "latest",
+        category: "dummy1",
+        isReported: true,
+        query: "alpha",
+      });
+
+      expect(result.items.map((p) => p.post.id)).toEqual([post1.id]);
+      expect(result.totalCount).toBe(1);
+      expect(post2.id).toBeDefined();
+    });
+  });
+
   describe("getPost", () => {
     it("success: 올바른 fields 반환", async () => {
       // Given: 글이 존재하는 경우

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { In, Repository } from "typeorm";
+import { Brackets, In, Repository } from "typeorm";
 import { Post, PostCategory } from "./entities/post.entity";
 import { PostLike } from "./entities/post-like.entity";
 import { Attachment } from "../attachment/entities/attachment.entity";
@@ -12,6 +12,9 @@ import {
   CursorPaginationResult,
 } from "src/common/helpers/pagination";
 import { executeCursorPagination } from "src/common/helpers/cursor";
+import { AdminListPostsQueryDtoSchema } from "@mindseed/api-types";
+import { z } from "zod";
+import { apiToEntityCategory } from "./post.mappers";
 
 /* shared types */
 
@@ -20,6 +23,15 @@ export type PostWithRelations = {
   withUser: {
     isOwner: boolean;
     isLiked: boolean;
+  };
+};
+
+export type PostWithAdminRelations = {
+  post: Post;
+  additional: {
+    likeCount: number;
+    commentCount: number;
+    reportCount: number;
   };
 };
 
@@ -35,6 +47,15 @@ export type ListPostsOptions = CursorPaginationOptions<ListPostsOrderBy> & {
 
 export type ListPostsResult = CursorPaginationResult<PostWithRelations> & {
   attachmentToUrl: AttachmentToUrlMap;
+};
+
+export type AdminListPostsOptions = z.output<
+  typeof AdminListPostsQueryDtoSchema
+>;
+
+export type AdminListPostsResult = {
+  items: PostWithAdminRelations[];
+  totalCount: number;
 };
 
 /* getPost */
@@ -135,6 +156,128 @@ export class PostQueryService {
       attachmentToUrl,
     };
   }
+
+  /*
+   * pagination을 적용하여 전체 글 목록을 조회한다.
+   * @returns 해당 글 리스트, url 빌더
+   */
+  async adminListPosts({
+    page,
+    limit,
+    orderBy,
+    category,
+    isReported,
+    query,
+  }: AdminListPostsOptions): Promise<AdminListPostsResult> {
+    const qb = this.postRepository
+      .createQueryBuilder("post")
+      .innerJoin("post.author", "author");
+
+    if (category) {
+      const entityCategory = apiToEntityCategory[category];
+      if (entityCategory !== undefined) {
+        qb.andWhere("post.category = :category", { category: entityCategory });
+      }
+    }
+
+    if (isReported) {
+      qb.andWhere(
+        "post.id IN (SELECT reported_post.post_id FROM report reported_post)",
+      );
+    }
+
+    if (query) {
+      qb.andWhere(
+        new Brackets((qb) => {
+          qb.where("post.content ILIKE :query", {
+            query: `%${query}%`,
+          }).orWhere("post.nickname ILIKE :query", { query: `%${query}%` });
+        }),
+      );
+    }
+
+    const totalCount = await qb.clone().getCount();
+    const skip = (page - 1) * limit;
+
+    let posts: Post[];
+    if (orderBy === "mostReported") {
+      const rows = await qb
+        .clone()
+        .select("post.id", "id")
+        .leftJoin("report", "order_report", "order_report.post_id = post.id")
+        .groupBy("post.id")
+        .orderBy('COUNT("order_report"."id")', "DESC")
+        .addOrderBy("post.id", "DESC")
+        .offset(skip)
+        .limit(limit)
+        .getRawMany<{ id: number }>();
+      const orderedIds = rows.map((row) => Number(row.id));
+      const postsById = new Map(
+        orderedIds.length > 0
+          ? (
+              await this.postRepository.find({
+                where: { id: In(orderedIds) },
+              })
+            ).map((post) => [post.id, post])
+          : [],
+      );
+      posts = orderedIds
+        .map((id) => postsById.get(id))
+        .filter((post): post is Post => post !== undefined);
+    } else {
+      if (orderBy === "latest") {
+        qb.orderBy("post.createdAt", "DESC").addOrderBy("post.id", "DESC");
+      } else {
+        qb.orderBy("post.createdAt", "ASC").addOrderBy("post.id", "ASC");
+      }
+      posts = await qb.offset(skip).limit(limit).getMany();
+    }
+
+    const postIds = posts.map((post) => post.id);
+
+    const [reportCounts, commentCounts] = await Promise.all([
+      this.getPostRelatedCounts("report", postIds),
+      this.getPostRelatedCounts("post_comment", postIds),
+    ]);
+
+    const result = posts.map((post) => ({
+      post: post,
+      additional: {
+        likeCount: post.likeCount,
+        commentCount: commentCounts[post.id] ?? 0,
+        reportCount: reportCounts[post.id] ?? 0,
+      },
+    }));
+
+    return {
+      items: result,
+      totalCount,
+    };
+  }
+
+  private async getPostRelatedCounts(
+    tableName: "report" | "post_comment",
+    postIds: number[],
+  ): Promise<Record<number, number>> {
+    if (postIds.length === 0) {
+      return {};
+    }
+
+    const rows = await this.postRepository.manager
+      .createQueryBuilder()
+      .select(`${tableName}.post_id`, "postId")
+      .addSelect("COUNT(*)", "count")
+      .from(tableName, tableName)
+      .where(`${tableName}.post_id IN (:...postIds)`, { postIds })
+      .groupBy(`${tableName}.post_id`)
+      .getRawMany<{ postId?: number; postid?: number; count: string }>();
+
+    return Object.fromEntries(
+      rows.map((row) => [Number(row.postId ?? row.postid), Number(row.count)]),
+    );
+  }
+
+  /* getPost */
 
   /**
    * postId에 대응하는 글이 존재하는지 확인한다.

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -103,8 +103,6 @@ export class PostQueryService {
     private readonly postCommentRepository: Repository<PostComment>,
     @InjectRepository(Report)
     private readonly reportRepository: Repository<Report>,
-    @InjectRepository(Attachment)
-    private readonly attachmentRepository: Repository<Attachment>,
     private readonly s3StorageService: S3StorageService,
   ) {}
 

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -15,6 +15,7 @@ import { executeCursorPagination } from "src/common/helpers/cursor";
 import { AdminListPostsQueryDtoSchema } from "@mindseed/api-types";
 import { z } from "zod";
 import { apiToEntityCategory } from "./post.mappers";
+import { Report } from "src/report/entities/report.entity";
 
 /* shared types */
 
@@ -72,6 +73,13 @@ export type GetPostResult = PostWithRelations & {
   comments: PostCommentWithType[];
 };
 
+export type AdminGetPostResult = {
+  post: Post;
+  attachmentToUrl: AttachmentToUrlMap;
+  comments: PostCommentWithType[];
+  reports: Report[];
+};
+
 const orderByMap = {
   createdAt: {
     sqlPath: "post.createdAt",
@@ -93,6 +101,10 @@ export class PostQueryService {
     private readonly postLikeRepository: Repository<PostLike>,
     @InjectRepository(PostComment)
     private readonly postCommentRepository: Repository<PostComment>,
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    @InjectRepository(Attachment)
+    private readonly attachmentRepository: Repository<Attachment>,
     private readonly s3StorageService: S3StorageService,
   ) {}
 
@@ -159,7 +171,7 @@ export class PostQueryService {
 
   /*
    * pagination을 적용하여 전체 글 목록을 조회한다.
-   * @returns 해당 글 리스트, url 빌더
+   * @returns 해당 글 리스트, 글 총 개수
    */
   async adminListPosts({
     page,
@@ -277,14 +289,57 @@ export class PostQueryService {
     );
   }
 
-  /* getPost */
-
   /**
    * postId에 대응하는 글이 존재하는지 확인한다.
    * @returns 존재하는 경우 true, 존재하지 않는 경우 false
    */
   async existsPost(postId: number): Promise<boolean> {
     return this.postRepository.existsBy({ id: postId });
+  }
+
+  /**
+   * postId에 대응하는 글 하나를 조회한다.
+   * @returns 해당 글, 카테고리, 내용, 작성 시각, 작성자 (익명), 이미지 빌더, 댓글, 신고 내역
+   */
+  async adminGetPost(postId: number): Promise<AdminGetPostResult> {
+    const post = await this.postRepository.findOne({
+      where: { id: postId },
+      relations: {
+        author: true,
+        attachments: true,
+        // comments: { author: true },
+      },
+    });
+
+    if (!post || !post.isActive()) {
+      throw new PostNotFoundError();
+    }
+
+    const attachmentToUrl = this.buildAttachmentToUrl(post.attachments);
+
+    const comments = await this.postCommentRepository
+      .createQueryBuilder("post_comment")
+      .leftJoinAndSelect("post_comment.author", "author")
+      .where("post_comment.postId = :postId", { postId })
+      .orderBy("post_comment.createdAt", "ASC")
+      .getMany();
+
+    const reports = await this.reportRepository
+      .createQueryBuilder("report")
+      .leftJoinAndSelect("report.author", "author")
+      .where("report.postId = :postId", { postId })
+      .orderBy("report.createdAt", "ASC")
+      .getMany();
+
+    return {
+      post,
+      attachmentToUrl,
+      comments: comments.map((comment) => ({
+        comment,
+        type: this.computeCommentType(comment),
+      })),
+      reports,
+    };
   }
 
   /**

--- a/apps/backend/src/post/post-query.service.ts
+++ b/apps/backend/src/post/post-query.service.ts
@@ -326,7 +326,8 @@ export class PostQueryService {
 
     const reports = await this.reportRepository
       .createQueryBuilder("report")
-      .leftJoinAndSelect("report.author", "author")
+      .leftJoinAndSelect("report.user", "user")
+      .leftJoinAndSelect("user.profile", "profile")
       .where("report.postId = :postId", { postId })
       .orderBy("report.createdAt", "ASC")
       .getMany();

--- a/apps/backend/src/post/post.admin.controller.ts
+++ b/apps/backend/src/post/post.admin.controller.ts
@@ -1,8 +1,10 @@
 import type {
+  AdminGetPostSuccessResponseDto,
   AdminListPostsQueryDto,
   AdminListPostsSuccessResponseDto,
 } from "@mindseed/api-types";
 import {
+  AdminGetPostResponseDtoSchema,
   AdminListPostsQueryDtoSchema,
   AdminListPostsResponseDtoSchema,
   idParamSchema,
@@ -59,10 +61,10 @@ export class PostAdminController {
   @Get(":id")
   @HttpCode(HttpStatus.OK)
   @AdminOnly()
-  @ZodEncodeResponse(GetPostResponseDtoSchema)
+  @ZodEncodeResponse(AdminGetPostResponseDtoSchema)
   async adminGetPost(
     @ZodParam("id", idParamSchema) id: number,
-  ): Promise<GetPostSuccessResponseDto> {
+  ): Promise<AdminGetPostSuccessResponseDto> {
     const { post, attachmentToUrl, comments, reports } =
       await this.postQueryService.adminGetPost(id);
 
@@ -105,6 +107,19 @@ export class PostAdminController {
                 author: { nickname: c.nickname },
               };
           }
+        }),
+        reports: reports.map((report) => {
+          return {
+            id: report.id,
+            reason: report.reason,
+            createdAt: report.createdAt,
+            postId: report.postId,
+            commentId: report.commentId,
+            range: report.range,
+            user: {
+              nickname: report.user?.profile?.nickname ?? "",
+            },
+          };
         }),
         likeCount: post.likeCount,
         createdAt: post.createdAt,

--- a/apps/backend/src/post/post.admin.controller.ts
+++ b/apps/backend/src/post/post.admin.controller.ts
@@ -1,0 +1,57 @@
+import type {
+  AdminListPostsQueryDto,
+  AdminListPostsSuccessResponseDto,
+} from "@mindseed/api-types";
+import {
+  AdminListPostsQueryDtoSchema,
+  AdminListPostsResponseDtoSchema,
+} from "@mindseed/api-types";
+import { Controller, Get, HttpCode, HttpStatus } from "@nestjs/common";
+import { AdminOnly } from "src/auth/decorators/auth.decorators";
+import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
+import { ZodQuery } from "src/common/pipes/zod-validation.decorator";
+import { PostQueryService } from "./post-query.service";
+import { entityToApiCategory } from "./post.mappers";
+
+@Controller("/admin/posts")
+export class PostAdminController {
+  constructor(private readonly postQueryService: PostQueryService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @AdminOnly()
+  @ZodEncodeResponse(AdminListPostsResponseDtoSchema)
+  async listPosts(
+    @ZodQuery(AdminListPostsQueryDtoSchema) query: AdminListPostsQueryDto,
+  ): Promise<AdminListPostsSuccessResponseDto> {
+    const { items: entries, totalCount } =
+      await this.postQueryService.adminListPosts({
+        page: query.page,
+        limit: query.limit,
+        orderBy: query.orderBy,
+        category: query.category,
+        isReported: query.isReported,
+        query: query.query,
+      });
+
+    return {
+      success: true,
+      data: {
+        posts: entries.map((post) => ({
+          id: post.post.id,
+          content: post.post.content,
+          category: entityToApiCategory[post.post.category],
+          author: {
+            nickname: post.post.nickname,
+          },
+          likeCount: post.additional.likeCount,
+          reportCount: post.additional.reportCount,
+          commentCount: post.additional.commentCount,
+          createdAt: post.post.createdAt,
+          updatedAt: post.post.updatedAt,
+        })),
+        totalCount,
+      },
+    };
+  }
+}

--- a/apps/backend/src/post/post.admin.controller.ts
+++ b/apps/backend/src/post/post.admin.controller.ts
@@ -1,24 +1,30 @@
 import type {
+  AdminDeletePostSuccessResponseDto,
   AdminGetPostSuccessResponseDto,
   AdminListPostsQueryDto,
   AdminListPostsSuccessResponseDto,
 } from "@mindseed/api-types";
 import {
+  AdminDeletePostResponseDtoSchema,
   AdminGetPostResponseDtoSchema,
   AdminListPostsQueryDtoSchema,
   AdminListPostsResponseDtoSchema,
   idParamSchema,
 } from "@mindseed/api-types";
-import { Controller, Get, HttpCode, HttpStatus } from "@nestjs/common";
+import { Controller, Delete, Get, HttpCode, HttpStatus } from "@nestjs/common";
 import { AdminOnly } from "src/auth/decorators/auth.decorators";
 import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
 import { ZodParam, ZodQuery } from "src/common/pipes/zod-validation.decorator";
 import { PostQueryService } from "./post-query.service";
 import { entityToApiCategory, entityToApiDeletionType } from "./post.mappers";
+import { PostMutationService } from "./post-mutation.service";
 
 @Controller("/admin/posts")
 export class PostAdminController {
-  constructor(private readonly postQueryService: PostQueryService) {}
+  constructor(
+    private readonly postQueryService: PostQueryService,
+    private readonly postMutationService: PostMutationService,
+  ) {}
 
   @Get()
   @HttpCode(HttpStatus.OK)
@@ -128,5 +134,16 @@ export class PostAdminController {
         updatedAt: post.updatedAt,
       },
     };
+  }
+
+  @Delete(":id")
+  @HttpCode(HttpStatus.OK)
+  @AdminOnly()
+  @ZodEncodeResponse(AdminDeletePostResponseDtoSchema)
+  async deleteAdminPost(
+    @ZodParam("id", idParamSchema) id: number,
+  ): Promise<AdminDeletePostSuccessResponseDto> {
+    await this.postMutationService.deleteAdminPost(id);
+    return { success: true, data: null };
   }
 }

--- a/apps/backend/src/post/post.admin.controller.ts
+++ b/apps/backend/src/post/post.admin.controller.ts
@@ -109,6 +109,10 @@ export class PostAdminController {
           }
         }),
         reports: reports.map((report) => {
+          const user = report.user?.profile
+            ? { nickname: report.user.profile.nickname }
+            : null;
+
           return {
             id: report.id,
             reason: report.reason,
@@ -116,9 +120,7 @@ export class PostAdminController {
             postId: report.postId,
             commentId: report.commentId,
             range: report.range,
-            user: {
-              nickname: report.user?.profile?.nickname ?? "",
-            },
+            user,
           };
         }),
         likeCount: post.likeCount,

--- a/apps/backend/src/post/post.admin.controller.ts
+++ b/apps/backend/src/post/post.admin.controller.ts
@@ -5,13 +5,14 @@ import type {
 import {
   AdminListPostsQueryDtoSchema,
   AdminListPostsResponseDtoSchema,
+  idParamSchema,
 } from "@mindseed/api-types";
 import { Controller, Get, HttpCode, HttpStatus } from "@nestjs/common";
 import { AdminOnly } from "src/auth/decorators/auth.decorators";
 import { ZodEncodeResponse } from "src/common/interceptors/zod-encode-response.decorator";
-import { ZodQuery } from "src/common/pipes/zod-validation.decorator";
+import { ZodParam, ZodQuery } from "src/common/pipes/zod-validation.decorator";
 import { PostQueryService } from "./post-query.service";
-import { entityToApiCategory } from "./post.mappers";
+import { entityToApiCategory, entityToApiDeletionType } from "./post.mappers";
 
 @Controller("/admin/posts")
 export class PostAdminController {
@@ -51,6 +52,63 @@ export class PostAdminController {
           updatedAt: post.post.updatedAt,
         })),
         totalCount,
+      },
+    };
+  }
+
+  @Get(":id")
+  @HttpCode(HttpStatus.OK)
+  @AdminOnly()
+  @ZodEncodeResponse(GetPostResponseDtoSchema)
+  async adminGetPost(
+    @ZodParam("id", idParamSchema) id: number,
+  ): Promise<GetPostSuccessResponseDto> {
+    const { post, attachmentToUrl, comments, reports } =
+      await this.postQueryService.adminGetPost(id);
+
+    return {
+      success: true,
+      data: {
+        id: post.id,
+        content: post.content,
+        category: entityToApiCategory[post.category],
+        author: { nickname: post.nickname },
+        attachments: post.attachments.map((a) => ({
+          id: a.id,
+          url: attachmentToUrl[a.id],
+        })),
+        comments: comments.map(({ comment: c, type }) => {
+          const common = {
+            id: c.id,
+            createdAt: c.createdAt,
+            updatedAt: c.updatedAt,
+          };
+
+          switch (type) {
+            case "deleted":
+              return {
+                ...common,
+                type,
+                deletionType: entityToApiDeletionType[c.deletionType!],
+              };
+            case "authorDeleted":
+              return {
+                ...common,
+                type,
+                content: c.content,
+              };
+            case "active":
+              return {
+                ...common,
+                type,
+                content: c.content,
+                author: { nickname: c.nickname },
+              };
+          }
+        }),
+        likeCount: post.likeCount,
+        createdAt: post.createdAt,
+        updatedAt: post.updatedAt,
       },
     };
   }

--- a/apps/backend/src/post/post.module.ts
+++ b/apps/backend/src/post/post.module.ts
@@ -11,10 +11,11 @@ import { PostAdminController } from "./post.admin.controller";
 import { S3StorageModule } from "src/s3-storage/s3-storage.module";
 import { AuthModule } from "src/auth/auth.module";
 import { UserModule } from "src/user/user.module";
+import { Report } from "src/report/entities/report.entity";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Post, PostLike, PostComment, Attachment]),
+    TypeOrmModule.forFeature([Post, PostLike, PostComment, Attachment, Report]),
     S3StorageModule,
     AuthModule,
     UserModule,

--- a/apps/backend/src/post/post.module.ts
+++ b/apps/backend/src/post/post.module.ts
@@ -7,6 +7,7 @@ import { Attachment } from "../attachment/entities/attachment.entity";
 import { PostQueryService } from "./post-query.service";
 import { PostMutationService } from "./post-mutation.service";
 import { PostController } from "./post.controller";
+import { PostAdminController } from "./post.admin.controller";
 import { S3StorageModule } from "src/s3-storage/s3-storage.module";
 import { AuthModule } from "src/auth/auth.module";
 import { UserModule } from "src/user/user.module";
@@ -18,7 +19,7 @@ import { UserModule } from "src/user/user.module";
     AuthModule,
     UserModule,
   ],
-  controllers: [PostController],
+  controllers: [PostController, PostAdminController],
   providers: [PostQueryService, PostMutationService],
   exports: [PostQueryService],
 })

--- a/apps/backend/src/s3-storage/entities/s3-queue.ts
+++ b/apps/backend/src/s3-storage/entities/s3-queue.ts
@@ -1,4 +1,7 @@
-import { CreateTimestampColumn } from "src/database/decorators/temporal.decorators";
+import {
+  CreateTimestampColumn,
+  TimestampColumn,
+} from "src/database/decorators/temporal.decorators";
 import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 import { Temporal } from "@js-temporal/polyfill";
 
@@ -25,4 +28,8 @@ export class S3Queue {
   // 생성 일시
   @CreateTimestampColumn()
   createdAt: Temporal.Instant;
+
+  // 처리 시작 일시
+  @TimestampColumn({ nullable: true })
+  processingStartedAt: Temporal.Instant | null;
 }

--- a/apps/backend/src/s3-storage/entities/s3-queue.ts
+++ b/apps/backend/src/s3-storage/entities/s3-queue.ts
@@ -1,0 +1,28 @@
+import { CreateTimestampColumn } from "src/database/decorators/temporal.decorators";
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Temporal } from "@js-temporal/polyfill";
+
+export enum S3QueueStatus {
+  PENDING = "PENDING",
+  PROCESSING = "PROCESSING",
+}
+
+@Entity({ name: "s3_queue" })
+export class S3Queue {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  attachmentKey: string;
+
+  @Column({ type: "enum", enum: S3QueueStatus, default: S3QueueStatus.PENDING })
+  status: S3QueueStatus;
+
+  // 시도 횟수
+  @Column({ default: 0 })
+  attemptCount: number;
+
+  // 생성 일시
+  @CreateTimestampColumn()
+  createdAt: Temporal.Instant;
+}

--- a/apps/backend/src/s3-storage/s3-client-storage.service.ts
+++ b/apps/backend/src/s3-storage/s3-client-storage.service.ts
@@ -60,11 +60,15 @@ export class S3ClientStorageService extends S3StorageService {
     }
 
     for (const key of keys) {
-      await this.s3QueueRepository.save(
-        this.s3QueueRepository.create({
-          attachmentKey: key,
-        }),
-      );
+      try {
+        await this.s3QueueRepository.save(
+          this.s3QueueRepository.create({
+            attachmentKey: key,
+          }),
+        );
+      } catch (error) {
+        console.error(`[S3ClientStorageService] failed to enqueue key=${key}`);
+      }
     }
 
     // await this.s3Client.send(

--- a/apps/backend/src/s3-storage/s3-client-storage.service.ts
+++ b/apps/backend/src/s3-storage/s3-client-storage.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Inject } from "@nestjs/common";
 import type { ConfigType } from "@nestjs/config";
 import {
-  DeleteObjectsCommand,
   HeadObjectCommand,
   NotFound,
   PutObjectCommand,
@@ -11,6 +10,9 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { S3_CLIENT } from "./s3-client.di-token";
 import { s3Config } from "src/config";
 import { S3StorageService } from "./s3-storage.service";
+import { InjectRepository } from "@nestjs/typeorm";
+import { S3Queue } from "./entities/s3-queue";
+import { Repository } from "typeorm";
 
 // 2026-03-26 testability를 위해 wrapper class 작성
 
@@ -20,6 +22,8 @@ export class S3ClientStorageService extends S3StorageService {
     @Inject(S3_CLIENT) private readonly s3Client: S3Client,
     @Inject(s3Config.KEY)
     private readonly s3cfg: ConfigType<typeof s3Config>,
+    @InjectRepository(S3Queue)
+    private readonly s3QueueRepository: Repository<S3Queue>,
   ) {
     super();
   }
@@ -55,13 +59,21 @@ export class S3ClientStorageService extends S3StorageService {
       return;
     }
 
-    await this.s3Client.send(
-      new DeleteObjectsCommand({
-        Bucket: this.s3cfg.bucket,
-        Delete: {
-          Objects: keys.map((key) => ({ Key: key })),
-        },
-      }),
-    );
+    for (const key of keys) {
+      await this.s3QueueRepository.save(
+        this.s3QueueRepository.create({
+          attachmentKey: key,
+        }),
+      );
+    }
+
+    // await this.s3Client.send(
+    //   new DeleteObjectsCommand({
+    //     Bucket: this.s3cfg.bucket,
+    //     Delete: {
+    //       Objects: keys.map((key) => ({ Key: key })),
+    //     },
+    //   }),
+    // );
   }
 }

--- a/apps/backend/src/s3-storage/s3-client-storage.service.ts
+++ b/apps/backend/src/s3-storage/s3-client-storage.service.ts
@@ -37,7 +37,12 @@ export class S3ClientStorageService extends S3StorageService {
   }
 
   getPublicUrl(key: string): string {
-    return `https://${this.s3cfg.endpoint}/${this.s3cfg.bucket}/${key}`;
+    const endpoint = this.s3cfg.endpoint!;
+    const baseUrl = endpoint.match(/^https?:\/\//)
+      ? endpoint
+      : `https://${endpoint}`;
+
+    return `${baseUrl.replace(/\/+$/, "")}/${this.s3cfg.bucket}/${key}`;
   }
 
   async exists(key: string): Promise<boolean> {

--- a/apps/backend/src/s3-storage/s3-client-storage.service.ts
+++ b/apps/backend/src/s3-storage/s3-client-storage.service.ts
@@ -59,15 +59,26 @@ export class S3ClientStorageService extends S3StorageService {
       return;
     }
 
+    /**
+     * 일시적인 DB 장애가 있을 수 있으므로 재시도 로직을 구현함.
+     * 하나의 실패가 모든 큐를 실패로 만들 수 있으므로, 각 큐를 개별적으로 처리하도록 함.
+     * 실패한 항목에 대해서는 로그를 남겨 나중에 디버깅 가능하도록 수정
+     */
     for (const key of keys) {
       try {
-        await this.s3QueueRepository.save(
-          this.s3QueueRepository.create({
+        await this.s3QueueRepository.save({
+          attachmentKey: key,
+        });
+      } catch (e) {
+        try {
+          await this.s3QueueRepository.save({
             attachmentKey: key,
-          }),
-        );
-      } catch (error) {
-        console.error(`[S3ClientStorageService] failed to enqueue key=${key}`);
+          });
+        } catch (e) {
+          console.error(
+            `[S3ClientStorageService] failed to enqueue key=${key} for deletion, error=${e}`,
+          );
+        }
       }
     }
 

--- a/apps/backend/src/s3-storage/s3-delete.cron.ts
+++ b/apps/backend/src/s3-storage/s3-delete.cron.ts
@@ -58,6 +58,15 @@ export class S3DeleteCron {
           deletedQueueIds.push(queue.id);
           console.log(`[S3DeleteCron] deleted id=${queue.id}`);
         } catch (error) {
+          if (queue.attemptCount >= 5) {
+            console.error(
+              `[S3DeleteCron] failed id=${queue.id}, key=${queue.attachmentKey}, error=${this.formatError(
+                error,
+              )}, giving up after ${queue.attemptCount} attempts`,
+            );
+            deletedQueueIds.push(queue.id);
+            continue;
+          }
           await this.markAsPendingWithRetry(queue);
           console.log(
             `[S3DeleteCron] failed id=${queue.id}, key=${queue.attachmentKey}, error=${this.formatError(error)}`,

--- a/apps/backend/src/s3-storage/s3-delete.cron.ts
+++ b/apps/backend/src/s3-storage/s3-delete.cron.ts
@@ -80,8 +80,8 @@ export class S3DeleteCron {
       const queues = await repository
         .createQueryBuilder("queue")
         .where("queue.status = :status", { status: S3QueueStatus.PENDING })
-        .orderBy("queue.createdAt", "DESC")
-        .addOrderBy("queue.id", "DESC")
+        .orderBy("queue.attemptCount", "DESC")
+        .addOrderBy("queue.createdAt", "DESC")
         .take(BATCH_SIZE)
         .setLock("pessimistic_write")
         .setOnLocked("skip_locked")

--- a/apps/backend/src/s3-storage/s3-delete.cron.ts
+++ b/apps/backend/src/s3-storage/s3-delete.cron.ts
@@ -3,6 +3,7 @@ import type { ConfigType } from "@nestjs/config";
 import { DeleteObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { InjectRepository } from "@nestjs/typeorm";
+import { Temporal } from "@js-temporal/polyfill";
 import { s3Config } from "src/config";
 import { In, Repository } from "typeorm";
 import { S3_CLIENT } from "./s3-client.di-token";
@@ -102,7 +103,10 @@ export class S3DeleteCron {
 
       await repository.update(
         { id: In(queues.map((queue) => queue.id)) },
-        { status: S3QueueStatus.PROCESSING },
+        {
+          status: S3QueueStatus.PROCESSING,
+          processingStartedAt: Temporal.Now.instant(),
+        },
       );
 
       return queues;
@@ -115,6 +119,7 @@ export class S3DeleteCron {
       {
         status: S3QueueStatus.PENDING,
         attemptCount: queue.attemptCount + 1,
+        processingStartedAt: null,
       },
     );
   }

--- a/apps/backend/src/s3-storage/s3-delete.cron.ts
+++ b/apps/backend/src/s3-storage/s3-delete.cron.ts
@@ -1,0 +1,119 @@
+import { Inject, Injectable } from "@nestjs/common";
+import type { ConfigType } from "@nestjs/config";
+import { DeleteObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { InjectRepository } from "@nestjs/typeorm";
+import { s3Config } from "src/config";
+import { In, Repository } from "typeorm";
+import { S3_CLIENT } from "./s3-client.di-token";
+import { S3Queue, S3QueueStatus } from "./entities/s3-queue";
+
+const BATCH_SIZE = 20;
+
+@Injectable()
+export class S3DeleteCron {
+  private isRunning = false;
+
+  constructor(
+    @Inject(S3_CLIENT) private readonly s3Client: S3Client,
+    @Inject(s3Config.KEY)
+    private readonly s3cfg: ConfigType<typeof s3Config>,
+    @InjectRepository(S3Queue)
+    private readonly s3QueueRepository: Repository<S3Queue>,
+  ) {}
+
+  @Cron(CronExpression.EVERY_5_SECONDS)
+  async handleCron(): Promise<void> {
+    if (this.isRunning) {
+      console.log("[S3DeleteCron] previous run is still processing");
+      return;
+    }
+
+    this.isRunning = true;
+
+    try {
+      const queues = await this.claimPendingQueues();
+      if (queues.length === 0) {
+        console.log("[S3DeleteCron] no pending objects");
+        return;
+      }
+
+      console.log(`[S3DeleteCron] claimed ${queues.length} objects`);
+
+      const deletedQueueIds: number[] = [];
+
+      for (const queue of queues) {
+        try {
+          console.log(
+            `[S3DeleteCron] deleting id=${queue.id}, key=${queue.attachmentKey}`,
+          );
+
+          await this.s3Client.send(
+            new DeleteObjectCommand({
+              Bucket: this.s3cfg.bucket!,
+              Key: queue.attachmentKey,
+            }),
+          );
+
+          deletedQueueIds.push(queue.id);
+          console.log(`[S3DeleteCron] deleted id=${queue.id}`);
+        } catch (error) {
+          await this.markAsPendingWithRetry(queue);
+          console.log(
+            `[S3DeleteCron] failed id=${queue.id}, key=${queue.attachmentKey}, error=${this.formatError(error)}`,
+          );
+        }
+      }
+
+      if (deletedQueueIds.length > 0) {
+        await this.s3QueueRepository.delete({ id: In(deletedQueueIds) });
+        console.log(`[S3DeleteCron] removed ${deletedQueueIds.length} queues`);
+      }
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  private async claimPendingQueues(): Promise<S3Queue[]> {
+    return this.s3QueueRepository.manager.transaction(async (manager) => {
+      const repository = manager.getRepository(S3Queue);
+      const queues = await repository
+        .createQueryBuilder("queue")
+        .where("queue.status = :status", { status: S3QueueStatus.PENDING })
+        .orderBy("queue.createdAt", "DESC")
+        .addOrderBy("queue.id", "DESC")
+        .take(BATCH_SIZE)
+        .setLock("pessimistic_write")
+        .setOnLocked("skip_locked")
+        .getMany();
+
+      if (queues.length === 0) {
+        return queues;
+      }
+
+      await repository.update(
+        { id: In(queues.map((queue) => queue.id)) },
+        { status: S3QueueStatus.PROCESSING },
+      );
+
+      return queues;
+    });
+  }
+
+  private async markAsPendingWithRetry(queue: S3Queue): Promise<void> {
+    await this.s3QueueRepository.update(
+      { id: queue.id },
+      {
+        status: S3QueueStatus.PENDING,
+        attemptCount: queue.attemptCount + 1,
+      },
+    );
+  }
+
+  private formatError(error: unknown): string {
+    if (error instanceof Error) {
+      return `${error.name}: ${error.message}`;
+    }
+    return String(error);
+  }
+}

--- a/apps/backend/src/s3-storage/s3-processing-recovery.cron.ts
+++ b/apps/backend/src/s3-storage/s3-processing-recovery.cron.ts
@@ -1,0 +1,34 @@
+import { Injectable } from "@nestjs/common";
+import { Temporal } from "@js-temporal/polyfill";
+import { Cron } from "@nestjs/schedule";
+import { InjectRepository } from "@nestjs/typeorm";
+import { LessThan, Repository } from "typeorm";
+import { S3Queue, S3QueueStatus } from "./entities/s3-queue";
+
+@Injectable()
+export class S3ProcessingRecoveryCron {
+  constructor(
+    @InjectRepository(S3Queue)
+    private readonly s3QueueRepository: Repository<S3Queue>,
+  ) {}
+
+  @Cron("0 */5 * * * *")
+  async handleCron(): Promise<void> {
+    const staleBefore = Temporal.Now.instant().subtract({ minutes: 10 });
+
+    const result = await this.s3QueueRepository.update(
+      {
+        status: S3QueueStatus.PROCESSING,
+        processingStartedAt: LessThan(staleBefore),
+      },
+      {
+        status: S3QueueStatus.PENDING,
+        processingStartedAt: null,
+      },
+    );
+
+    console.log(
+      `[S3ProcessingRecoveryCron] recovered ${result.affected ?? 0} stale processing queues`,
+    );
+  }
+}

--- a/apps/backend/src/s3-storage/s3-storage.module.ts
+++ b/apps/backend/src/s3-storage/s3-storage.module.ts
@@ -1,14 +1,19 @@
 import { Module } from "@nestjs/common";
 import { ConfigType } from "@nestjs/config";
+import { TypeOrmModule } from "@nestjs/typeorm";
 import { S3Client } from "@aws-sdk/client-s3";
 import { s3Config } from "src/config";
 import { S3StorageService } from "./s3-storage.service";
 import { S3ClientStorageService } from "./s3-client-storage.service";
 import { S3_CLIENT } from "./s3-client.di-token";
+import { S3Queue } from "./entities/s3-queue";
+import { S3DeleteCron } from "./s3-delete.cron";
 
 @Module({
+  imports: [TypeOrmModule.forFeature([S3Queue])],
   providers: [
     { provide: S3StorageService, useClass: S3ClientStorageService },
+    S3DeleteCron,
     {
       provide: S3_CLIENT,
       inject: [s3Config.KEY],

--- a/apps/backend/src/s3-storage/s3-storage.module.ts
+++ b/apps/backend/src/s3-storage/s3-storage.module.ts
@@ -8,12 +8,14 @@ import { S3ClientStorageService } from "./s3-client-storage.service";
 import { S3_CLIENT } from "./s3-client.di-token";
 import { S3Queue } from "./entities/s3-queue";
 import { S3DeleteCron } from "./s3-delete.cron";
+import { S3ProcessingRecoveryCron } from "./s3-processing-recovery.cron";
 
 @Module({
   imports: [TypeOrmModule.forFeature([S3Queue])],
   providers: [
     { provide: S3StorageService, useClass: S3ClientStorageService },
     S3DeleteCron,
+    S3ProcessingRecoveryCron,
     {
       provide: S3_CLIENT,
       inject: [s3Config.KEY],

--- a/packages/api-types/src/common/post.ts
+++ b/packages/api-types/src/common/post.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import { dateSerializerCodec } from "./codecs";
 import { AuthorDtoSchema } from "./author";
 import { CommentDtoSchema } from "./comment";
+import { ReportDtoSchema } from "./report";
 
 export const PostContentSchema = z.string().min(1).max(200);
 
@@ -41,4 +42,9 @@ export const AdminPostDtoSchema = z.object({
 
 export const PostWithCommentsSchema = PostDtoSchema.extend({
   comments: z.array(CommentDtoSchema),
+});
+
+export const AdminPostWithCommentsSchema = AdminPostDtoSchema.extend({
+  comments: z.array(CommentDtoSchema),
+  reports: z.array(ReportDtoSchema),
 });

--- a/packages/api-types/src/common/post.ts
+++ b/packages/api-types/src/common/post.ts
@@ -27,6 +27,18 @@ export const PostDtoSchema = z.object({
   updatedAt: dateSerializerCodec,
 });
 
+export const AdminPostDtoSchema = z.object({
+  id: z.int(),
+  content: PostContentSchema,
+  category: PostCategorySchema,
+  author: AuthorDtoSchema,
+  likeCount: z.int(),
+  reportCount: z.int(),
+  commentCount: z.int(),
+  createdAt: dateSerializerCodec,
+  updatedAt: dateSerializerCodec,
+});
+
 export const PostWithCommentsSchema = PostDtoSchema.extend({
   comments: z.array(CommentDtoSchema),
 });

--- a/packages/api-types/src/common/post.ts
+++ b/packages/api-types/src/common/post.ts
@@ -44,7 +44,15 @@ export const PostWithCommentsSchema = PostDtoSchema.extend({
   comments: z.array(CommentDtoSchema),
 });
 
-export const AdminPostWithCommentsSchema = AdminPostDtoSchema.extend({
+export const AdminPostWithCommentsSchema = z.object({
+  id: z.int(),
+  content: PostContentSchema,
+  category: PostCategorySchema,
+  author: AuthorDtoSchema,
+  likeCount: z.int(),
+  createdAt: dateSerializerCodec,
+  updatedAt: dateSerializerCodec,
+  attachments: z.array(AttachmentDtoSchema).max(3),
   comments: z.array(CommentDtoSchema),
   reports: z.array(ReportDtoSchema),
 });

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -37,6 +37,7 @@ export * from "./posts/set-post-like";
 export * from "./posts/delete-post";
 export * from "./posts/admin/admin-list-posts";
 export * from "./posts/admin/admin-get-post";
+export * from "./posts/admin/admin-delete-post";
 
 export * from "./post-comments/create-comment";
 export * from "./post-comments/update-comment";

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -36,6 +36,7 @@ export * from "./posts/update-post";
 export * from "./posts/set-post-like";
 export * from "./posts/delete-post";
 export * from "./posts/admin/admin-list-posts";
+export * from "./posts/admin/admin-get-post";
 
 export * from "./post-comments/create-comment";
 export * from "./post-comments/update-comment";

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -35,6 +35,7 @@ export * from "./posts/get-post";
 export * from "./posts/update-post";
 export * from "./posts/set-post-like";
 export * from "./posts/delete-post";
+export * from "./posts/admin/admin-list-posts";
 
 export * from "./post-comments/create-comment";
 export * from "./post-comments/update-comment";

--- a/packages/api-types/src/posts/admin/admin-delete-post.ts
+++ b/packages/api-types/src/posts/admin/admin-delete-post.ts
@@ -1,0 +1,25 @@
+/*
+ DELETE /admin/posts/:id
+ Auth: ADMIN role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../../helpers";
+import { PostErrorCode } from "../../common/error-codes";
+
+export const AdminDeletePostResponseDtoSchema = responseDtoSchema(
+  z.null(),
+  z.enum([PostErrorCode.POST_NOT_FOUND, PostErrorCode.NOT_POST_AUTHOR]),
+);
+
+export type AdminDeletePostResponseDto = z.output<
+  typeof AdminDeletePostResponseDtoSchema
+>;
+export type AdminDeletePostSuccessResponseDto = Extract<
+  AdminDeletePostResponseDto,
+  { success: true }
+>;
+export type AdminDeletePostErrorResponseDto = Extract<
+  AdminDeletePostResponseDto,
+  { success: false }
+>;

--- a/packages/api-types/src/posts/admin/admin-delete-post.ts
+++ b/packages/api-types/src/posts/admin/admin-delete-post.ts
@@ -9,7 +9,7 @@ import { PostErrorCode } from "../../common/error-codes";
 
 export const AdminDeletePostResponseDtoSchema = responseDtoSchema(
   z.null(),
-  z.enum([PostErrorCode.POST_NOT_FOUND, PostErrorCode.NOT_POST_AUTHOR]),
+  z.enum([PostErrorCode.POST_NOT_FOUND]),
 );
 
 export type AdminDeletePostResponseDto = z.output<

--- a/packages/api-types/src/posts/admin/admin-get-post.ts
+++ b/packages/api-types/src/posts/admin/admin-get-post.ts
@@ -1,5 +1,5 @@
 /*
- GET /posts/:id
+ GET /admin/posts/:id
  Auth: ADMIN role
  */
 

--- a/packages/api-types/src/posts/admin/admin-get-post.ts
+++ b/packages/api-types/src/posts/admin/admin-get-post.ts
@@ -1,0 +1,24 @@
+/*
+ GET /posts/:id
+ Auth: USER role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../../helpers";
+import { PostWithCommentsSchema } from "../../common/post";
+import { PostErrorCode } from "../../common/error-codes";
+
+export const GetPostResponseDtoSchema = responseDtoSchema(
+  PostWithCommentsSchema,
+  z.enum([PostErrorCode.POST_NOT_FOUND]),
+);
+
+export type GetPostResponseDto = z.output<typeof GetPostResponseDtoSchema>;
+export type GetPostSuccessResponseDto = Extract<
+  GetPostResponseDto,
+  { success: true }
+>;
+export type GetPostErrorResponseDto = Extract<
+  GetPostResponseDto,
+  { success: false }
+>;

--- a/packages/api-types/src/posts/admin/admin-get-post.ts
+++ b/packages/api-types/src/posts/admin/admin-get-post.ts
@@ -5,10 +5,7 @@
 
 import z from "zod";
 import { responseDtoSchema } from "../../helpers";
-import {
-  AdminPostWithCommentsSchema,
-  PostWithCommentsSchema,
-} from "../../common/post";
+import { AdminPostWithCommentsSchema } from "../../common/post";
 import { PostErrorCode } from "../../common/error-codes";
 
 export const AdminGetPostResponseDtoSchema = responseDtoSchema(

--- a/packages/api-types/src/posts/admin/admin-get-post.ts
+++ b/packages/api-types/src/posts/admin/admin-get-post.ts
@@ -1,24 +1,29 @@
 /*
  GET /posts/:id
- Auth: USER role
+ Auth: ADMIN role
  */
 
 import z from "zod";
 import { responseDtoSchema } from "../../helpers";
-import { PostWithCommentsSchema } from "../../common/post";
+import {
+  AdminPostWithCommentsSchema,
+  PostWithCommentsSchema,
+} from "../../common/post";
 import { PostErrorCode } from "../../common/error-codes";
 
-export const GetPostResponseDtoSchema = responseDtoSchema(
-  PostWithCommentsSchema,
+export const AdminGetPostResponseDtoSchema = responseDtoSchema(
+  AdminPostWithCommentsSchema,
   z.enum([PostErrorCode.POST_NOT_FOUND]),
 );
 
-export type GetPostResponseDto = z.output<typeof GetPostResponseDtoSchema>;
-export type GetPostSuccessResponseDto = Extract<
-  GetPostResponseDto,
+export type AdminGetPostResponseDto = z.output<
+  typeof AdminGetPostResponseDtoSchema
+>;
+export type AdminGetPostSuccessResponseDto = Extract<
+  AdminGetPostResponseDto,
   { success: true }
 >;
-export type GetPostErrorResponseDto = Extract<
-  GetPostResponseDto,
+export type AdminGetPostErrorResponseDto = Extract<
+  AdminGetPostResponseDto,
   { success: false }
 >;

--- a/packages/api-types/src/posts/admin/admin-list-posts.ts
+++ b/packages/api-types/src/posts/admin/admin-list-posts.ts
@@ -23,7 +23,7 @@ export const AdminListPostsQueryDtoSchema = z.object({
   orderBy: AdminListPostsOrderByFieldsSchema.default("latest"),
   category: PostCategorySchema.optional(),
   isReported: booleanSerializerCodec.default(false),
-  query: z.string().optional(),
+  query: z.string().max(200).optional(),
 });
 
 export type AdminListPostsQueryDto = z.output<

--- a/packages/api-types/src/posts/admin/admin-list-posts.ts
+++ b/packages/api-types/src/posts/admin/admin-list-posts.ts
@@ -1,0 +1,53 @@
+/*
+ GET /admin/posts
+ Auth: ADMIN role
+ */
+
+import z from "zod";
+import { responseDtoSchema } from "../../helpers";
+import { AdminPostDtoSchema, PostCategorySchema } from "../../common/post";
+import {
+  booleanSerializerCodec,
+  numberSerializerCodec,
+} from "../../common/codecs";
+
+export const AdminListPostsOrderByFieldsSchema = z.enum([
+  "latest",
+  "oldest",
+  "mostReported",
+]);
+
+export const AdminListPostsQueryDtoSchema = z.object({
+  page: numberSerializerCodec.pipe(z.number().int().min(1)).default(1),
+  limit: numberSerializerCodec
+    .pipe(z.number().int().min(1).max(100))
+    .default(10),
+  orderBy: AdminListPostsOrderByFieldsSchema.default("latest"),
+  category: PostCategorySchema.optional(),
+  isReported: booleanSerializerCodec.default(false),
+  query: z.string().optional(),
+});
+
+export type AdminListPostsQueryDto = z.output<
+  typeof AdminListPostsQueryDtoSchema
+>;
+
+export const AdminListPostsResponseDtoSchema = responseDtoSchema(
+  z.object({
+    posts: z.array(AdminPostDtoSchema),
+    totalCount: numberSerializerCodec.pipe(z.number().int().min(0)),
+  }),
+  z.never(),
+);
+
+export type AdminListPostsResponseDto = z.output<
+  typeof AdminListPostsResponseDtoSchema
+>;
+export type AdminListPostsSuccessResponseDto = Extract<
+  AdminListPostsResponseDto,
+  { success: true }
+>;
+export type AdminListPostsErrorResponseDto = Extract<
+  AdminListPostsResponseDto,
+  { success: false }
+>;

--- a/packages/api-types/src/posts/admin/admin-list-posts.ts
+++ b/packages/api-types/src/posts/admin/admin-list-posts.ts
@@ -18,10 +18,8 @@ export const AdminListPostsOrderByFieldsSchema = z.enum([
 ]);
 
 export const AdminListPostsQueryDtoSchema = z.object({
-  page: numberSerializerCodec.pipe(z.number().int().min(1)).default(1),
-  limit: numberSerializerCodec
-    .pipe(z.number().int().min(1).max(100))
-    .default(10),
+  page: numberSerializerCodec.pipe(z.int().min(1)).default(1),
+  limit: numberSerializerCodec.pipe(z.int().min(1).max(100)).default(10),
   orderBy: AdminListPostsOrderByFieldsSchema.default("latest"),
   category: PostCategorySchema.optional(),
   isReported: booleanSerializerCodec.default(false),
@@ -35,7 +33,7 @@ export type AdminListPostsQueryDto = z.output<
 export const AdminListPostsResponseDtoSchema = responseDtoSchema(
   z.object({
     posts: z.array(AdminPostDtoSchema),
-    totalCount: numberSerializerCodec.pipe(z.number().int().min(0)),
+    totalCount: z.int().min(0),
   }),
   z.never(),
 );


### PR DESCRIPTION
# 요약
- #138 구현 완료 (어드민 글 관련 로직)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an admin-only posts interface for listing, viewing, and deleting posts (`/admin/posts`).
  - Supports pagination, sorting (latest/oldest/most reported), category filtering, reported-status filtering, and free-text search.
  - Admin post details include attachment URLs, comments, reports, and engagement counts.
  - Introduced queued/background deletion of S3 objects for attachment removals.
- **Bug Fixes**
  - Admin view/delete now consistently returns a not-found response for missing, inactive, or soft-deleted (withdrawn-author) posts.
- **Tests**
  - Expanded coverage for admin listing and deletion, including ordering, filtering, count accuracy, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->