### PR TITLE
사용자 및 커뮤니티 API 연동

### DIFF
--- a/apps/backend/src/post/post.admin.controller.ts
+++ b/apps/backend/src/post/post.admin.controller.ts
@@ -111,6 +111,7 @@ export class PostAdminController {
                 type,
                 content: c.content,
                 author: { nickname: c.nickname },
+                isOwner: false,
               };
           }
         }),

--- a/apps/backend/src/post/post.controller.ts
+++ b/apps/backend/src/post/post.controller.ts
@@ -166,6 +166,7 @@ export class PostController {
                 type,
                 content: c.content,
                 author: { nickname: c.nickname },
+                isOwner: c.authorId === user.id,
               };
           }
         }),

--- a/apps/backend/src/post/post.mappers.ts
+++ b/apps/backend/src/post/post.mappers.ts
@@ -10,10 +10,10 @@ type ApiPostCategory = z.output<typeof PostCategorySchema>;
 type ApiDeletionType = z.output<typeof DeletionTypeSchema>;
 
 export const apiToEntityCategory: Record<ApiPostCategory, PostCategory> = {
-  concern: PostCategory.CONCERN,
-  diary: PostCategory.DIARY,
-  inquiry: PostCategory.INQUIRY,
-  other: PostCategory.OTHER,
+  CONCERN: PostCategory.CONCERN,
+  DIARY: PostCategory.DIARY,
+  INQUIRY: PostCategory.INQUIRY,
+  OTHER: PostCategory.OTHER,
 };
 
 export const entityToApiDeletionType: Record<DeletionType, ApiDeletionType> = {
@@ -22,8 +22,8 @@ export const entityToApiDeletionType: Record<DeletionType, ApiDeletionType> = {
 };
 
 export const entityToApiCategory: Record<PostCategory, ApiPostCategory> = {
-  [PostCategory.CONCERN]: "concern",
-  [PostCategory.DIARY]: "diary",
-  [PostCategory.INQUIRY]: "inquiry",
-  [PostCategory.OTHER]: "other",
+  [PostCategory.CONCERN]: "CONCERN",
+  [PostCategory.DIARY]: "DIARY",
+  [PostCategory.INQUIRY]: "INQUIRY",
+  [PostCategory.OTHER]: "OTHER",
 };

--- a/apps/frontend-user/package.json
+++ b/apps/frontend-user/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@mindseed/api-types": "workspace:*",
+    "@tanstack/react-query": "^5.101.4",
     "dayjs": "^1.11.21",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/apps/frontend-user/src/App.tsx
+++ b/apps/frontend-user/src/App.tsx
@@ -1,8 +1,18 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "react-router";
 import { router } from "./Router";
+import { ApiError } from "./api/api";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: (failureCount, error) => {
+        if (error instanceof ApiError && error.statusCode < 500) return false;
+        return failureCount < 3;
+      },
+    },
+  },
+});
 
 function App() {
   return (

--- a/apps/frontend-user/src/App.tsx
+++ b/apps/frontend-user/src/App.tsx
@@ -1,11 +1,14 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "react-router";
 import { router } from "./Router";
 
+const queryClient = new QueryClient();
+
 function App() {
   return (
-    <>
+    <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
-    </>
+    </QueryClientProvider>
   );
 }
 

--- a/apps/frontend-user/src/Router.tsx
+++ b/apps/frontend-user/src/Router.tsx
@@ -1,106 +1,71 @@
-import { createBrowserRouter } from "react-router";
+import { createBrowserRouter, redirect } from "react-router";
 import { Layout } from "./components/Layout";
 import { Home } from "./pages/Home";
 import { Onboarding } from "./pages/Onboarding";
 import { Login } from "./pages/Auth/Login";
 import { SignUp } from "./pages/Auth/SignUp";
 import { PasswordReset } from "./pages/Auth/PasswordReset";
-import { Diagnoses } from "./pages/Diagnoses/Diagnoses";
-import { DiagnosesResult } from "./pages/Diagnoses/DiagnosesResult";
 import { CommunityMainPage } from "./pages/Community/Community";
 import { PostDetailPage } from "./pages/Community/PostDetail";
 import { PostWritePage } from "./pages/Community/PostWrite";
-import { Contents } from "./pages/Contents/Contents";
-import { Mission } from "./pages/Mission/Mission";
-import { MyPage } from "./pages/MyPage/MyPage";
-import { NicknameChange } from "./pages/MyPage/NicknameChange";
-import { CharacterChange } from "./pages/MyPage/CharacterChange";
-import { MyPosts } from "./pages/MyPage/MyPosts";
-import { Counsel } from "./pages/Counsel/Counsel";
-import { CounselWrite } from "./pages/Counsel/CounselWrite";
-import { CounselDetail } from "./pages/Counsel/CounselDetail";
+import { refreshTokens } from "./api/api";
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  setTokens,
+} from "./api/tokens";
+
+async function bootstrap(): Promise<void> {
+  if (getAccessToken() !== null) return;
+  const rt = getRefreshToken();
+  if (rt === null) return;
+  try {
+    const tokens = await refreshTokens(rt);
+    setTokens(tokens.accessToken, tokens.refreshToken);
+  } catch {
+    clearTokens();
+  }
+}
+
+async function appLoader() {
+  await bootstrap();
+  if (getAccessToken() === null) return redirect("/onboarding");
+  return null;
+}
+
+async function authLoader() {
+  await bootstrap();
+  if (getAccessToken() !== null) return redirect("/");
+  return null;
+}
 
 export const router = createBrowserRouter([
   {
     element: <Layout />,
     children: [
       {
-        path: "/onboarding",
-        element: <Onboarding />,
-      },
-      {
-        path: "/login",
-        element: <Login />,
-      },
-      {
-        path: "/signup",
-        element: <SignUp />,
-      },
-      {
-        path: "/password-reset",
-        element: <PasswordReset />,
-      },
-      {
-        path: "/diagnoses",
+        loader: authLoader,
         children: [
-          {
-            index: true,
-            element: <Diagnoses />,
-          },
-          {
-            path: "result",
-            element: <DiagnosesResult />,
-          },
+          { path: "/onboarding", element: <Onboarding /> },
+          { path: "/login", element: <Login /> },
+          { path: "/signup", element: <SignUp /> },
+          { path: "/password-reset", element: <PasswordReset /> },
         ],
       },
       {
-        path: "/",
-        element: <Home />,
-      },
-      {
-        path: "/mission",
-        element: <Mission />,
-      },
-      {
-        path: "/community",
+        loader: appLoader,
         children: [
+          { path: "/", element: <Home /> },
           {
-            index: true,
-            element: <CommunityMainPage />,
+            path: "/community",
+            children: [
+              { index: true, element: <CommunityMainPage /> },
+              { path: "write", element: <PostWritePage /> },
+              { path: ":postId", element: <PostDetailPage /> },
+              { path: ":postId/edit", element: <PostWritePage /> },
+            ],
           },
-          {
-            path: "write",
-            element: <PostWritePage />,
-          },
-          {
-            path: ":postId",
-            element: <PostDetailPage />,
-          },
-          {
-            path: ":postId/edit",
-            element: <PostWritePage />,
-          },
-        ],
-      },
-      {
-        path: "/contents",
-        element: <Contents />,
-      },
-      {
-        path: "/mypage",
-        children: [
-          { index: true, element: <MyPage /> },
-          { path: "nickname", element: <NicknameChange /> },
-          { path: "character", element: <CharacterChange /> },
-          { path: "posts", element: <MyPosts /> },
-        ],
-      },
-      {
-        path: "/counsel",
-        children: [
-          { index: true, element: <Counsel /> },
-          { path: "write", element: <CounselWrite /> },
-          { path: ":counselId", element: <CounselDetail /> },
         ],
       },
     ],

--- a/apps/frontend-user/src/Router.tsx
+++ b/apps/frontend-user/src/Router.tsx
@@ -8,13 +8,14 @@ import { PasswordReset } from "./pages/Auth/PasswordReset";
 import { CommunityMainPage } from "./pages/Community/Community";
 import { PostDetailPage } from "./pages/Community/PostDetail";
 import { PostWritePage } from "./pages/Community/PostWrite";
-import { refreshTokens } from "./api/api";
+import { ApiError, refreshTokens } from "./api/api";
 import {
   clearTokens,
   getAccessToken,
   getRefreshToken,
   setTokens,
 } from "./api/tokens";
+import { AuthErrorCode } from "@mindseed/api-types";
 
 let bootstrapPromise: Promise<void> | null = null;
 
@@ -26,8 +27,10 @@ async function bootstrap(): Promise<void> {
     try {
       const tokens = await refreshTokens(rt);
       setTokens(tokens.accessToken, tokens.refreshToken);
-    } catch {
-      clearTokens();
+    } catch (e) {
+      if (e instanceof ApiError && e.errorCode === AuthErrorCode.INVALID_REFRESH_TOKEN) {
+        clearTokens();
+      }
     } finally {
       bootstrapPromise = null;
     }

--- a/apps/frontend-user/src/Router.tsx
+++ b/apps/frontend-user/src/Router.tsx
@@ -16,16 +16,23 @@ import {
   setTokens,
 } from "./api/tokens";
 
+let bootstrapPromise: Promise<void> | null = null;
+
 async function bootstrap(): Promise<void> {
   if (getAccessToken() !== null) return;
   const rt = getRefreshToken();
   if (rt === null) return;
-  try {
-    const tokens = await refreshTokens(rt);
-    setTokens(tokens.accessToken, tokens.refreshToken);
-  } catch {
-    clearTokens();
-  }
+  bootstrapPromise ??= (async () => {
+    try {
+      const tokens = await refreshTokens(rt);
+      setTokens(tokens.accessToken, tokens.refreshToken);
+    } catch {
+      clearTokens();
+    } finally {
+      bootstrapPromise = null;
+    }
+  })();
+  await bootstrapPromise;
 }
 
 async function appLoader() {

--- a/apps/frontend-user/src/api/api.ts
+++ b/apps/frontend-user/src/api/api.ts
@@ -1,0 +1,162 @@
+import {
+  CompleteSignupRequestDtoSchema,
+  CompleteSignupResponseDtoSchema,
+  EmailPasswordResetRequestDtoSchema,
+  EmailPasswordResetResponseDtoSchema,
+  LoginRequestDtoSchema,
+  LoginResponseDtoSchema,
+  LogoutResponseDtoSchema,
+  RefreshTokensResponseDtoSchema,
+  ResetPasswordRequestDtoSchema,
+  ResetPasswordResponseDtoSchema,
+  SendMailRequestDtoSchema,
+  SendMailResponseDtoSchema,
+  VerifyMailRequestDtoSchema,
+  VerifyMailResponseDtoSchema,
+} from "@mindseed/api-types";
+import type {
+  CompleteSignupRequestDto,
+  EmailPasswordResetRequestDto,
+  LoginRequestDto,
+  ResetPasswordRequestDto,
+  SendMailRequestDto,
+  VerifyMailRequestDto,
+} from "@mindseed/api-types";
+import type { ZodType } from "zod";
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+if (!BASE_URL) throw new Error("VITE_API_BASE_URL is not set");
+
+export class ApiError extends Error {
+  readonly statusCode: number;
+  readonly errorCode: string | undefined;
+
+  constructor(code: string | undefined, statusCode: number) {
+    super(code ?? `HTTP ${statusCode}`);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+    this.errorCode = code;
+  }
+}
+
+type Options = { signal?: AbortSignal };
+
+async function post<TData>(
+  path: string,
+  body: unknown,
+  schema: ZodType<
+    | { success: true; data: TData }
+    | { success: false; statusCode: number; errorCode?: string }
+  >,
+  options?: Options & { token?: string },
+): Promise<TData> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (options?.token) {
+    headers["Authorization"] = `Bearer ${options.token}`;
+  }
+
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    signal: options?.signal,
+  });
+
+  const json: unknown = await response.json();
+  const parsed = schema.parse(json);
+
+  if (!parsed.success) {
+    throw new ApiError(parsed.errorCode, parsed.statusCode);
+  }
+
+  return parsed.data;
+}
+
+export async function sendSignUpMail(
+  input: SendMailRequestDto,
+  options?: Options,
+): Promise<void> {
+  await post(
+    "/auth/email/sign-up",
+    SendMailRequestDtoSchema.parse(input),
+    SendMailResponseDtoSchema,
+    options,
+  );
+}
+
+export async function sendPasswordResetMail(
+  input: EmailPasswordResetRequestDto,
+  options?: Options,
+): Promise<void> {
+  await post(
+    "/auth/email/password-reset",
+    EmailPasswordResetRequestDtoSchema.parse(input),
+    EmailPasswordResetResponseDtoSchema,
+    options,
+  );
+}
+
+export async function getEmailToken(
+  input: VerifyMailRequestDto,
+  options?: Options,
+) {
+  return post(
+    "/auth/email/token",
+    VerifyMailRequestDtoSchema.parse(input),
+    VerifyMailResponseDtoSchema,
+    options,
+  );
+}
+
+export async function signUp(
+  token: string,
+  input: CompleteSignupRequestDto,
+  options?: Options,
+) {
+  return post(
+    "/auth/sign-up",
+    CompleteSignupRequestDtoSchema.parse(input),
+    CompleteSignupResponseDtoSchema,
+    { ...options, token },
+  );
+}
+
+export async function resetPassword(
+  token: string,
+  input: ResetPasswordRequestDto,
+  options?: Options,
+): Promise<void> {
+  await post(
+    "/auth/reset-password",
+    ResetPasswordRequestDtoSchema.parse(input),
+    ResetPasswordResponseDtoSchema,
+    { ...options, token },
+  );
+}
+
+export async function login(input: LoginRequestDto, options?: Options) {
+  return post(
+    "/auth/login",
+    LoginRequestDtoSchema.parse(input),
+    LoginResponseDtoSchema,
+    options,
+  );
+}
+
+export async function refreshTokens(token: string, options?: Options) {
+  return post(
+    "/auth/refresh-tokens",
+    undefined,
+    RefreshTokensResponseDtoSchema,
+    { ...options, token },
+  );
+}
+
+export async function logout(token: string, options?: Options): Promise<void> {
+  await post("/auth/logout", undefined, LogoutResponseDtoSchema, {
+    ...options,
+    token,
+  });
+}

--- a/apps/frontend-user/src/api/api.ts
+++ b/apps/frontend-user/src/api/api.ts
@@ -1,25 +1,41 @@
 import {
-  CompleteSignupRequestDtoSchema,
+  BeginAttachmentUploadResponseDtoSchema,
   CompleteSignupResponseDtoSchema,
-  EmailPasswordResetRequestDtoSchema,
+  ConfirmAttachmentUploadResponseDtoSchema,
+  CreateCommentResponseDtoSchema,
+  CreateCommentReportResponseDtoSchema,
+  CreatePostResponseDtoSchema,
+  CreatePostReportResponseDtoSchema,
+  DeleteCommentResponseDtoSchema,
+  DeletePostResponseDtoSchema,
   EmailPasswordResetResponseDtoSchema,
-  LoginRequestDtoSchema,
+  GetPostResponseDtoSchema,
+  ListPostsResponseDtoSchema,
   LoginResponseDtoSchema,
   LogoutResponseDtoSchema,
   RefreshTokensResponseDtoSchema,
-  ResetPasswordRequestDtoSchema,
   ResetPasswordResponseDtoSchema,
-  SendMailRequestDtoSchema,
   SendMailResponseDtoSchema,
-  VerifyMailRequestDtoSchema,
+  SetPostLikeResponseDtoSchema,
+  UpdateCommentResponseDtoSchema,
+  UpdatePostResponseDtoSchema,
   VerifyMailResponseDtoSchema,
 } from "@mindseed/api-types";
 import type {
   CompleteSignupRequestDto,
+  ConfirmAttachmentUploadRequestDto,
+  CreateCommentRequestDto,
+  CreateCommentReportRequestDto,
+  CreatePostRequestDto,
+  CreatePostReportRequestDto,
   EmailPasswordResetRequestDto,
+  ListPostsQueryDto,
   LoginRequestDto,
   ResetPasswordRequestDto,
   SendMailRequestDto,
+  SetPostLikeRequestDto,
+  UpdateCommentRequestDto,
+  UpdatePostRequestDto,
   VerifyMailRequestDto,
 } from "@mindseed/api-types";
 import type { ZodType } from "zod";
@@ -74,16 +90,135 @@ async function post<TData>(
   return parsed.data;
 }
 
+async function get<TData>(
+  path: string,
+  schema: ZodType<
+    | { success: true; data: TData }
+    | { success: false; statusCode: number; errorCode?: string }
+  >,
+  options?: Options & { token?: string },
+): Promise<TData> {
+  const headers: Record<string, string> = {};
+  if (options?.token) {
+    headers["Authorization"] = `Bearer ${options.token}`;
+  }
+
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: "GET",
+    headers,
+    signal: options?.signal,
+  });
+
+  const json: unknown = await response.json();
+  const parsed = schema.parse(json);
+
+  if (!parsed.success) {
+    throw new ApiError(parsed.errorCode, parsed.statusCode);
+  }
+
+  return parsed.data;
+}
+
+async function put<TData>(
+  path: string,
+  body: unknown,
+  schema: ZodType<
+    | { success: true; data: TData }
+    | { success: false; statusCode: number; errorCode?: string }
+  >,
+  options?: Options & { token?: string },
+): Promise<TData> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (options?.token) {
+    headers["Authorization"] = `Bearer ${options.token}`;
+  }
+
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify(body),
+    signal: options?.signal,
+  });
+
+  const json: unknown = await response.json();
+  const parsed = schema.parse(json);
+
+  if (!parsed.success) {
+    throw new ApiError(parsed.errorCode, parsed.statusCode);
+  }
+
+  return parsed.data;
+}
+
+async function patch<TData>(
+  path: string,
+  body: unknown,
+  schema: ZodType<
+    | { success: true; data: TData }
+    | { success: false; statusCode: number; errorCode?: string }
+  >,
+  options?: Options & { token?: string },
+): Promise<TData> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (options?.token) {
+    headers["Authorization"] = `Bearer ${options.token}`;
+  }
+
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(body),
+    signal: options?.signal,
+  });
+
+  const json: unknown = await response.json();
+  const parsed = schema.parse(json);
+
+  if (!parsed.success) {
+    throw new ApiError(parsed.errorCode, parsed.statusCode);
+  }
+
+  return parsed.data;
+}
+
+async function del<TData>(
+  path: string,
+  schema: ZodType<
+    | { success: true; data: TData }
+    | { success: false; statusCode: number; errorCode?: string }
+  >,
+  options?: Options & { token?: string },
+): Promise<TData> {
+  const headers: Record<string, string> = {};
+  if (options?.token) {
+    headers["Authorization"] = `Bearer ${options.token}`;
+  }
+
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: "DELETE",
+    headers,
+    signal: options?.signal,
+  });
+
+  const json: unknown = await response.json();
+  const parsed = schema.parse(json);
+
+  if (!parsed.success) {
+    throw new ApiError(parsed.errorCode, parsed.statusCode);
+  }
+
+  return parsed.data;
+}
+
 export async function sendSignUpMail(
   input: SendMailRequestDto,
   options?: Options,
 ): Promise<void> {
-  await post(
-    "/auth/email/sign-up",
-    SendMailRequestDtoSchema.parse(input),
-    SendMailResponseDtoSchema,
-    options,
-  );
+  await post("/auth/email/sign-up", input, SendMailResponseDtoSchema, options);
 }
 
 export async function sendPasswordResetMail(
@@ -92,7 +227,7 @@ export async function sendPasswordResetMail(
 ): Promise<void> {
   await post(
     "/auth/email/password-reset",
-    EmailPasswordResetRequestDtoSchema.parse(input),
+    input,
     EmailPasswordResetResponseDtoSchema,
     options,
   );
@@ -102,12 +237,7 @@ export async function getEmailToken(
   input: VerifyMailRequestDto,
   options?: Options,
 ) {
-  return post(
-    "/auth/email/token",
-    VerifyMailRequestDtoSchema.parse(input),
-    VerifyMailResponseDtoSchema,
-    options,
-  );
+  return post("/auth/email/token", input, VerifyMailResponseDtoSchema, options);
 }
 
 export async function signUp(
@@ -115,12 +245,10 @@ export async function signUp(
   input: CompleteSignupRequestDto,
   options?: Options,
 ) {
-  return post(
-    "/auth/sign-up",
-    CompleteSignupRequestDtoSchema.parse(input),
-    CompleteSignupResponseDtoSchema,
-    { ...options, token },
-  );
+  return post("/auth/sign-up", input, CompleteSignupResponseDtoSchema, {
+    ...options,
+    token,
+  });
 }
 
 export async function resetPassword(
@@ -128,21 +256,14 @@ export async function resetPassword(
   input: ResetPasswordRequestDto,
   options?: Options,
 ): Promise<void> {
-  await post(
-    "/auth/reset-password",
-    ResetPasswordRequestDtoSchema.parse(input),
-    ResetPasswordResponseDtoSchema,
-    { ...options, token },
-  );
+  await post("/auth/reset-password", input, ResetPasswordResponseDtoSchema, {
+    ...options,
+    token,
+  });
 }
 
 export async function login(input: LoginRequestDto, options?: Options) {
-  return post(
-    "/auth/login",
-    LoginRequestDtoSchema.parse(input),
-    LoginResponseDtoSchema,
-    options,
-  );
+  return post("/auth/login", input, LoginResponseDtoSchema, options);
 }
 
 export async function refreshTokens(token: string, options?: Options) {
@@ -156,6 +277,166 @@ export async function refreshTokens(token: string, options?: Options) {
 
 export async function logout(token: string, options?: Options): Promise<void> {
   await post("/auth/logout", undefined, LogoutResponseDtoSchema, {
+    ...options,
+    token,
+  });
+}
+
+export async function getPosts(
+  token: string,
+  query: ListPostsQueryDto,
+  options?: Options,
+) {
+  const params = new URLSearchParams();
+  if (query.cursor) params.set("cursor", query.cursor);
+  params.set("limit", String(query.limit));
+  params.set("orderBy", query.orderBy);
+  params.set("orderDirection", query.orderDirection);
+  if (query.category) params.set("category", query.category);
+  return get(`/posts?${params}`, ListPostsResponseDtoSchema, {
+    ...options,
+    token,
+  });
+}
+
+export async function getPost(
+  token: string,
+  postId: number,
+  options?: Options,
+) {
+  return get(`/posts/${postId}`, GetPostResponseDtoSchema, {
+    ...options,
+    token,
+  });
+}
+
+export async function createPost(
+  token: string,
+  input: CreatePostRequestDto,
+  options?: Options,
+) {
+  return post("/posts", input, CreatePostResponseDtoSchema, {
+    ...options,
+    token,
+  });
+}
+
+export async function updatePost(
+  token: string,
+  postId: number,
+  input: UpdatePostRequestDto,
+  options?: Options,
+): Promise<void> {
+  await put(`/posts/${postId}`, input, UpdatePostResponseDtoSchema, {
+    ...options,
+    token,
+  });
+}
+
+export async function setPostLike(
+  token: string,
+  postId: number,
+  input: SetPostLikeRequestDto,
+  options?: Options,
+): Promise<void> {
+  await put(`/posts/${postId}/like`, input, SetPostLikeResponseDtoSchema, {
+    ...options,
+    token,
+  });
+}
+
+export async function deletePost(
+  token: string,
+  postId: number,
+  options?: Options,
+): Promise<void> {
+  await del(`/posts/${postId}`, DeletePostResponseDtoSchema, {
+    ...options,
+    token,
+  });
+}
+
+export async function createComment(
+  token: string,
+  postId: number,
+  input: CreateCommentRequestDto,
+  options?: Options,
+) {
+  return post(
+    `/posts/${postId}/comments`,
+    input,
+    CreateCommentResponseDtoSchema,
+    { ...options, token },
+  );
+}
+
+export async function updateComment(
+  token: string,
+  postId: number,
+  commentId: number,
+  input: UpdateCommentRequestDto,
+  options?: Options,
+): Promise<void> {
+  await patch(
+    `/posts/${postId}/comments/${commentId}`,
+    input,
+    UpdateCommentResponseDtoSchema,
+    { ...options, token },
+  );
+}
+
+export async function deleteComment(
+  token: string,
+  postId: number,
+  commentId: number,
+  options?: Options,
+): Promise<void> {
+  await del(
+    `/posts/${postId}/comments/${commentId}`,
+    DeleteCommentResponseDtoSchema,
+    { ...options, token },
+  );
+}
+
+export async function beginAttachmentUpload(token: string, options?: Options) {
+  return post(
+    "/attachments/begin",
+    undefined,
+    BeginAttachmentUploadResponseDtoSchema,
+    { ...options, token },
+  );
+}
+
+export async function confirmAttachmentUpload(
+  token: string,
+  input: ConfirmAttachmentUploadRequestDto,
+  options?: Options,
+): Promise<void> {
+  await post(
+    "/attachments/confirm",
+    input,
+    ConfirmAttachmentUploadResponseDtoSchema,
+    { ...options, token },
+  );
+}
+
+export async function createPostReport(
+  token: string,
+  input: CreatePostReportRequestDto,
+  options?: Options,
+): Promise<void> {
+  await post("/reports/post", input, CreatePostReportResponseDtoSchema, {
+    ...options,
+    token,
+  });
+}
+
+export async function createCommentReport(
+  token: string,
+  input: CreateCommentReportRequestDto,
+  options?: Options,
+): Promise<void> {
+  await post("/reports/comment", input, CreateCommentReportResponseDtoSchema, {
     ...options,
     token,
   });

--- a/apps/frontend-user/src/api/api.ts
+++ b/apps/frontend-user/src/api/api.ts
@@ -57,13 +57,38 @@ export class ApiError extends Error {
 
 type Options = { signal?: AbortSignal };
 
+type ResponseSchema<TData> = ZodType<
+  | { success: true; data: TData }
+  | { success: false; statusCode: number; errorCode?: string }
+>;
+
+async function parseResponse<TData>(
+  response: Response,
+  schema: ResponseSchema<TData>,
+): Promise<TData> {
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    throw new ApiError(undefined, response.status);
+  }
+
+  const result = schema.safeParse(json);
+  if (!result.success) {
+    throw new ApiError(undefined, response.status);
+  }
+
+  if (!result.data.success) {
+    throw new ApiError(result.data.errorCode, result.data.statusCode);
+  }
+
+  return result.data.data;
+}
+
 async function post<TData>(
   path: string,
   body: unknown,
-  schema: ZodType<
-    | { success: true; data: TData }
-    | { success: false; statusCode: number; errorCode?: string }
-  >,
+  schema: ResponseSchema<TData>,
   options?: Options & { token?: string },
 ): Promise<TData> {
   const headers: Record<string, string> = {
@@ -80,22 +105,12 @@ async function post<TData>(
     signal: options?.signal,
   });
 
-  const json: unknown = await response.json();
-  const parsed = schema.parse(json);
-
-  if (!parsed.success) {
-    throw new ApiError(parsed.errorCode, parsed.statusCode);
-  }
-
-  return parsed.data;
+  return parseResponse(response, schema);
 }
 
 async function get<TData>(
   path: string,
-  schema: ZodType<
-    | { success: true; data: TData }
-    | { success: false; statusCode: number; errorCode?: string }
-  >,
+  schema: ResponseSchema<TData>,
   options?: Options & { token?: string },
 ): Promise<TData> {
   const headers: Record<string, string> = {};
@@ -109,23 +124,13 @@ async function get<TData>(
     signal: options?.signal,
   });
 
-  const json: unknown = await response.json();
-  const parsed = schema.parse(json);
-
-  if (!parsed.success) {
-    throw new ApiError(parsed.errorCode, parsed.statusCode);
-  }
-
-  return parsed.data;
+  return parseResponse(response, schema);
 }
 
 async function put<TData>(
   path: string,
   body: unknown,
-  schema: ZodType<
-    | { success: true; data: TData }
-    | { success: false; statusCode: number; errorCode?: string }
-  >,
+  schema: ResponseSchema<TData>,
   options?: Options & { token?: string },
 ): Promise<TData> {
   const headers: Record<string, string> = {
@@ -142,23 +147,13 @@ async function put<TData>(
     signal: options?.signal,
   });
 
-  const json: unknown = await response.json();
-  const parsed = schema.parse(json);
-
-  if (!parsed.success) {
-    throw new ApiError(parsed.errorCode, parsed.statusCode);
-  }
-
-  return parsed.data;
+  return parseResponse(response, schema);
 }
 
 async function patch<TData>(
   path: string,
   body: unknown,
-  schema: ZodType<
-    | { success: true; data: TData }
-    | { success: false; statusCode: number; errorCode?: string }
-  >,
+  schema: ResponseSchema<TData>,
   options?: Options & { token?: string },
 ): Promise<TData> {
   const headers: Record<string, string> = {
@@ -175,22 +170,12 @@ async function patch<TData>(
     signal: options?.signal,
   });
 
-  const json: unknown = await response.json();
-  const parsed = schema.parse(json);
-
-  if (!parsed.success) {
-    throw new ApiError(parsed.errorCode, parsed.statusCode);
-  }
-
-  return parsed.data;
+  return parseResponse(response, schema);
 }
 
 async function del<TData>(
   path: string,
-  schema: ZodType<
-    | { success: true; data: TData }
-    | { success: false; statusCode: number; errorCode?: string }
-  >,
+  schema: ResponseSchema<TData>,
   options?: Options & { token?: string },
 ): Promise<TData> {
   const headers: Record<string, string> = {};
@@ -204,14 +189,7 @@ async function del<TData>(
     signal: options?.signal,
   });
 
-  const json: unknown = await response.json();
-  const parsed = schema.parse(json);
-
-  if (!parsed.success) {
-    throw new ApiError(parsed.errorCode, parsed.statusCode);
-  }
-
-  return parsed.data;
+  return parseResponse(response, schema);
 }
 
 export async function sendSignUpMail(

--- a/apps/frontend-user/src/api/callAuthenticated.ts
+++ b/apps/frontend-user/src/api/callAuthenticated.ts
@@ -1,0 +1,52 @@
+import type { NavigateFunction } from "react-router";
+import { ApiError, refreshTokens } from "./api";
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  setTokens,
+} from "./tokens";
+
+let refreshInFlight: Promise<void> | null = null;
+
+async function doRefresh(): Promise<void> {
+  const rt = getRefreshToken();
+  if (rt === null) throw new Error("No refresh token");
+  const tokens = await refreshTokens(rt);
+  setTokens(tokens.accessToken, tokens.refreshToken);
+}
+
+function ensureRefresh(): Promise<void> {
+  if (refreshInFlight === null) {
+    refreshInFlight = doRefresh().finally(() => {
+      refreshInFlight = null;
+    });
+  }
+  return refreshInFlight;
+}
+
+export async function callAuthenticated<T>(
+  fn: (token: string) => Promise<T>,
+  navigate: NavigateFunction,
+): Promise<T> {
+  const token = getAccessToken();
+  if (token === null) {
+    throw new Error("Invariant: callAuthenticated called without access token");
+  }
+
+  try {
+    return await fn(token);
+  } catch (e) {
+    if (!(e instanceof ApiError) || e.statusCode !== 401) throw e;
+
+    try {
+      await ensureRefresh();
+    } catch {
+      clearTokens();
+      navigate("/onboarding");
+      throw e;
+    }
+
+    return fn(getAccessToken()!);
+  }
+}

--- a/apps/frontend-user/src/api/callAuthenticated.ts
+++ b/apps/frontend-user/src/api/callAuthenticated.ts
@@ -7,16 +7,17 @@ import {
   setTokens,
 } from "./tokens";
 
-let refreshInFlight: Promise<void> | null = null;
+let refreshInFlight: Promise<string> | null = null;
 
-async function doRefresh(): Promise<void> {
+async function doRefresh(): Promise<string> {
   const rt = getRefreshToken();
   if (rt === null) throw new Error("No refresh token");
   const tokens = await refreshTokens(rt);
   setTokens(tokens.accessToken, tokens.refreshToken);
+  return tokens.accessToken;
 }
 
-function ensureRefresh(): Promise<void> {
+function ensureRefresh(): Promise<string> {
   if (refreshInFlight === null) {
     refreshInFlight = doRefresh().finally(() => {
       refreshInFlight = null;
@@ -39,14 +40,15 @@ export async function callAuthenticated<T>(
   } catch (e) {
     if (!(e instanceof ApiError) || e.statusCode !== 401) throw e;
 
+    let refreshedToken: string;
     try {
-      await ensureRefresh();
+      refreshedToken = await ensureRefresh();
     } catch {
       clearTokens();
       navigate("/onboarding");
       throw e;
     }
 
-    return fn(getAccessToken()!);
+    return fn(refreshedToken);
   }
 }

--- a/apps/frontend-user/src/api/tokens.ts
+++ b/apps/frontend-user/src/api/tokens.ts
@@ -1,0 +1,21 @@
+const REFRESH_TOKEN_KEY = "refreshToken";
+
+let accessToken: string | null = null;
+
+export function setTokens(at: string, rt: string): void {
+  accessToken = at;
+  localStorage.setItem(REFRESH_TOKEN_KEY, rt);
+}
+
+export function clearTokens(): void {
+  accessToken = null;
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+}
+
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+export function getRefreshToken(): string | null {
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}

--- a/apps/frontend-user/src/components/Community/Post.tsx
+++ b/apps/frontend-user/src/components/Community/Post.tsx
@@ -7,6 +7,7 @@ import { TEXT_STYLE } from "../../style/typography";
 import { Picture } from "../Picture";
 import { LikeButton } from "./LikeButton";
 import type { PostDto } from "../../type/index";
+import { getPostCategoryLabel } from "../../postCategory";
 dayjs.extend(relativeTime);
 dayjs.locale("ko");
 
@@ -57,7 +58,7 @@ export const Post = ({
           <Picture pictures={attachments} />
         )}
         <Footer>
-          <Category>#{category.replace(/^#/, "")}</Category>
+          <Category>#{getPostCategoryLabel(category)}</Category>
           {variant === "list" && (
             <LikeArea onClick={(event) => event.stopPropagation()}>
               <LikeButton isLiked={isLiked} onClick={onLikeClick} />

--- a/apps/frontend-user/src/components/Community/ReportModal.tsx
+++ b/apps/frontend-user/src/components/Community/ReportModal.tsx
@@ -27,26 +27,27 @@ export const ReportModal = ({
     if (!isOpen) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onCancel();
+      if (event.key === "Escape" && !isPending) onCancel();
     };
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onCancel]);
+  }, [isOpen, isPending, onCancel]);
 
   if (!isOpen) return null;
 
   return (
-    <Overlay onClick={onCancel}>
+    <Overlay onClick={isPending ? undefined : onCancel}>
       <Modal
-        role="alertdialog"
+        role="dialog"
         aria-modal="true"
+        aria-labelledby="report-modal-title"
         onClick={(event) => event.stopPropagation()}
       >
         <WarningIcon width={48} height={48} color={COLORS.state.error} />
 
         <Message>
-          <Title>신고하기</Title>
+          <Title id="report-modal-title">신고하기</Title>
           <Description>신고 사유를 입력해주세요.</Description>
         </Message>
 
@@ -66,7 +67,7 @@ export const ReportModal = ({
           >
             신고
           </ConfirmButton>
-          <CancelButton type="button" onClick={onCancel}>
+          <CancelButton type="button" disabled={isPending} onClick={onCancel}>
             취소
           </CancelButton>
         </Actions>
@@ -164,4 +165,9 @@ const CancelButton = styled.button`
   color: ${COLORS.gray.gray600};
   ${TEXT_STYLE.title.ti};
   cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 `;

--- a/apps/frontend-user/src/components/Community/ReportModal.tsx
+++ b/apps/frontend-user/src/components/Community/ReportModal.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+import { COLORS } from "../../style/colors";
+import { TEXT_STYLE } from "../../style/typography";
+import { WarningIcon } from "../Icons/WarningIcon";
+
+type ReportModalProps = {
+  isOpen: boolean;
+  isPending: boolean;
+  onConfirm: (reason: string) => void;
+  onCancel: () => void;
+};
+
+export const ReportModal = ({
+  isOpen,
+  isPending,
+  onConfirm,
+  onCancel,
+}: ReportModalProps) => {
+  const [reason, setReason] = useState("");
+
+  useEffect(() => {
+    if (isOpen) setReason("");
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onCancel();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  return (
+    <Overlay onClick={onCancel}>
+      <Modal
+        role="alertdialog"
+        aria-modal="true"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <WarningIcon width={48} height={48} color={COLORS.state.error} />
+
+        <Message>
+          <Title>신고하기</Title>
+          <Description>신고 사유를 입력해주세요.</Description>
+        </Message>
+
+        <ReasonInput
+          value={reason}
+          placeholder="신고 사유를 입력하세요"
+          maxLength={200}
+          onChange={(event) => setReason(event.target.value)}
+          autoFocus
+        />
+
+        <Actions>
+          <ConfirmButton
+            type="button"
+            disabled={!reason.trim() || isPending}
+            onClick={() => onConfirm(reason.trim())}
+          >
+            신고
+          </ConfirmButton>
+          <CancelButton type="button" onClick={onCancel}>
+            취소
+          </CancelButton>
+        </Actions>
+      </Modal>
+    </Overlay>
+  );
+};
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1.25rem;
+  background: color-mix(in srgb, ${COLORS.text.black} 30%, transparent);
+`;
+
+const Modal = styled.div`
+  width: min(80%, 22.0625rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background: ${COLORS.gray.gray0};
+`;
+
+const Message = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-top: 1rem;
+  text-align: center;
+`;
+
+const Title = styled.h2`
+  color: ${COLORS.text.black};
+  ${TEXT_STYLE.title.sm};
+`;
+
+const Description = styled.p`
+  color: ${COLORS.gray.gray600};
+  ${TEXT_STYLE.body.sm};
+`;
+
+const ReasonInput = styled.textarea`
+  width: 100%;
+  margin-top: 1rem;
+  padding: 0.75rem;
+  border: 1px solid ${COLORS.gray.gray300};
+  border-radius: 8px;
+  outline: none;
+  resize: none;
+  height: 6rem;
+  color: ${COLORS.text.black};
+  ${TEXT_STYLE.body.sm};
+  box-sizing: border-box;
+
+  &::placeholder {
+    color: ${COLORS.gray.gray400};
+  }
+`;
+
+const Actions = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  margin-top: 1rem;
+`;
+
+const ConfirmButton = styled.button`
+  width: 100%;
+  padding: 1rem 1.25rem;
+  border: none;
+  border-radius: 12px;
+  background: ${COLORS.state.error};
+  color: ${COLORS.gray.gray0};
+  ${TEXT_STYLE.title.ti};
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const CancelButton = styled.button`
+  width: 100%;
+  padding: 1rem 1.25rem;
+  border: none;
+  border-radius: 12px;
+  background: none;
+  color: ${COLORS.gray.gray600};
+  ${TEXT_STYLE.title.ti};
+  cursor: pointer;
+`;

--- a/apps/frontend-user/src/pages/Auth/Login.tsx
+++ b/apps/frontend-user/src/pages/Auth/Login.tsx
@@ -1,12 +1,24 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router";
+import { useMutation } from "@tanstack/react-query";
 import { styled } from "styled-components";
 import { Button } from "../../components/Button";
 import { TextInput } from "../../components/TextInput";
 import { TopBar } from "../../components/TopBar";
 import { COLORS } from "../../style/colors";
 import { TEXT_STYLE } from "../../style/typography";
-import { LoginRequestDtoSchema } from "../../type/index";
+import { LoginRequestDtoSchema } from "@mindseed/api-types";
+import type { LoginRequestDto } from "@mindseed/api-types";
+import { ApiError, login } from "../../api/api";
+import { setTokens } from "../../api/tokens";
+
+function getLoginErrorMessage(error: Error | null): string {
+  if (error === null) return "";
+  if (error instanceof ApiError && error.errorCode === "INVALID_CREDENTIALS") {
+    return "이메일 또는 비밀번호가 올바르지 않습니다.";
+  }
+  return "로그인 중 오류가 발생했습니다. 다시 시도해주세요.";
+}
 
 export const Login = () => {
   const navigate = useNavigate();
@@ -15,25 +27,26 @@ export const Login = () => {
   const [emailError, setEmailError] = useState("");
   const [passwordError, setPasswordError] = useState("");
 
+  const loginMutation = useMutation({
+    mutationFn: (input: LoginRequestDto) => login(input),
+    onSuccess: (data) => {
+      setTokens(data.accessToken, data.refreshToken);
+      void navigate("/");
+    },
+  });
+
+  const apiError = getLoginErrorMessage(loginMutation.error);
+
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!email.trim() || !password) return;
-
-    const loginResult = LoginRequestDtoSchema.safeParse({
-      email: email.trim(),
-      password,
-    });
-
-    if (!loginResult.success) {
-      setEmailError("올바른 이메일 형식이 아닙니다.");
-      setPasswordError("");
+    const result = LoginRequestDtoSchema.safeParse({ email, password });
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      setEmailError(fieldErrors.email?.[0] ?? "");
+      setPasswordError(fieldErrors.password?.[0] ?? "");
       return;
     }
-
-    setEmailError("");
-    setPasswordError("");
-
-    navigate("/");
+    loginMutation.mutate(result.data);
   };
 
   return (
@@ -60,6 +73,7 @@ export const Login = () => {
               onChange={(event) => {
                 setEmail(event.target.value);
                 setEmailError("");
+                loginMutation.reset();
               }}
             />
           </Field>
@@ -70,13 +84,14 @@ export const Login = () => {
               name="login-password"
               type="password"
               value={password}
-              status={passwordError ? "error" : "normal"}
-              description={passwordError}
+              status={passwordError || apiError ? "error" : "normal"}
+              description={passwordError || apiError}
               placeholder="비밀번호를 입력해주세요."
               adornmentType="icon"
               onChange={(event) => {
                 setPassword(event.target.value);
                 setPasswordError("");
+                loginMutation.reset();
               }}
             />
           </Field>
@@ -88,7 +103,7 @@ export const Login = () => {
             size="medium"
             type="submit"
             label="로그인"
-            disabled={!email.trim() || !password}
+            disabled={loginMutation.isPending}
           />
 
           <Links>

--- a/apps/frontend-user/src/pages/Auth/Login.tsx
+++ b/apps/frontend-user/src/pages/Auth/Login.tsx
@@ -7,14 +7,14 @@ import { TextInput } from "../../components/TextInput";
 import { TopBar } from "../../components/TopBar";
 import { COLORS } from "../../style/colors";
 import { TEXT_STYLE } from "../../style/typography";
-import { LoginRequestDtoSchema } from "@mindseed/api-types";
+import { AuthErrorCode, LoginRequestDtoSchema } from "@mindseed/api-types";
 import type { LoginRequestDto } from "@mindseed/api-types";
 import { ApiError, login } from "../../api/api";
 import { setTokens } from "../../api/tokens";
 
 function getLoginErrorMessage(error: Error | null): string {
   if (error === null) return "";
-  if (error instanceof ApiError && error.errorCode === "INVALID_CREDENTIALS") {
+  if (error instanceof ApiError && error.errorCode === AuthErrorCode.INVALID_CREDENTIALS) {
     return "이메일 또는 비밀번호가 올바르지 않습니다.";
   }
   return "로그인 중 오류가 발생했습니다. 다시 시도해주세요.";

--- a/apps/frontend-user/src/pages/Auth/PasswordReset.tsx
+++ b/apps/frontend-user/src/pages/Auth/PasswordReset.tsx
@@ -21,6 +21,7 @@ import {
   resetPassword,
 } from "../../api/api";
 import { AuthErrorCode } from "@mindseed/api-types";
+import { getEmailTokenErrorMessage } from "./authErrors";
 import type {
   EmailPasswordResetRequestDto,
   VerifyMailRequestDto,
@@ -40,17 +41,6 @@ function getSendPasswordResetMailErrorMessage(error: Error | null): string {
     }
   }
   return "인증 코드 발송 중 오류가 발생했습니다. 다시 시도해주세요.";
-}
-
-function getEmailTokenErrorMessage(error: Error | null): string {
-  if (error === null) return "";
-  if (
-    error instanceof ApiError &&
-    error.errorCode === AuthErrorCode.INVALID_VERIFICATION_CODE
-  ) {
-    return "인증 코드가 올바르지 않습니다.";
-  }
-  return "인증 중 오류가 발생했습니다. 다시 시도해주세요.";
 }
 
 function getResetPasswordErrorMessage(error: Error | null): string {
@@ -133,6 +123,7 @@ export const PasswordReset = () => {
 
   const handleBack = () => {
     if (step === "password") {
+      verificationTimer.reset();
       setStep("code");
       return;
     }

--- a/apps/frontend-user/src/pages/Auth/PasswordReset.tsx
+++ b/apps/frontend-user/src/pages/Auth/PasswordReset.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
+import { useMutation } from "@tanstack/react-query";
 import { styled } from "styled-components";
 import { Button } from "../../components/Button";
 import { TextInput } from "../../components/TextInput";
@@ -13,8 +14,55 @@ import {
   ResetPasswordRequestDtoSchema,
   VerifyMailRequestDtoSchema,
 } from "../../type/index";
+import {
+  ApiError,
+  sendPasswordResetMail,
+  getEmailToken,
+  resetPassword,
+} from "../../api/api";
+import { AuthErrorCode } from "@mindseed/api-types";
+import type {
+  EmailPasswordResetRequestDto,
+  VerifyMailRequestDto,
+  ResetPasswordRequestDto,
+} from "@mindseed/api-types";
 
 type PasswordResetStep = "email" | "code" | "password";
+
+function getSendPasswordResetMailErrorMessage(error: Error | null): string {
+  if (error === null) return "";
+  if (error instanceof ApiError) {
+    if (error.errorCode === AuthErrorCode.EMAIL_RATE_LIMITED) {
+      return "이메일 발송 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.";
+    }
+    if (error.errorCode === AuthErrorCode.VERIFICATION_COOLDOWN) {
+      return "인증 코드를 다시 받으려면 30초 후에 시도해주세요.";
+    }
+  }
+  return "인증 코드 발송 중 오류가 발생했습니다. 다시 시도해주세요.";
+}
+
+function getEmailTokenErrorMessage(error: Error | null): string {
+  if (error === null) return "";
+  if (
+    error instanceof ApiError &&
+    error.errorCode === AuthErrorCode.INVALID_VERIFICATION_CODE
+  ) {
+    return "인증 코드가 올바르지 않습니다.";
+  }
+  return "인증 중 오류가 발생했습니다. 다시 시도해주세요.";
+}
+
+function getResetPasswordErrorMessage(error: Error | null): string {
+  if (error === null) return "";
+  if (
+    error instanceof ApiError &&
+    error.errorCode === AuthErrorCode.INVALID_PASSWORD_RESET_TOKEN
+  ) {
+    return "인증이 만료되었습니다. 처음부터 다시 시도해주세요.";
+  }
+  return "비밀번호 변경 중 오류가 발생했습니다. 다시 시도해주세요.";
+}
 
 export const PasswordReset = () => {
   const navigate = useNavigate();
@@ -28,13 +76,60 @@ export const PasswordReset = () => {
   const [verificationCodeError, setVerificationCodeError] = useState("");
   const [passwordError, setPasswordError] = useState("");
   const [passwordConfirmError, setPasswordConfirmError] = useState("");
+  const [emailToken, setEmailToken] = useState<string | null>(null);
+
+  const sendPasswordResetMailMutation = useMutation({
+    mutationFn: (input: EmailPasswordResetRequestDto) =>
+      sendPasswordResetMail(input),
+    onSuccess: () => {
+      setVerificationCode("");
+      verificationTimer.reset();
+      setStep("code");
+    },
+  });
+
+  const getEmailTokenMutation = useMutation({
+    mutationFn: (input: VerifyMailRequestDto) => getEmailToken(input),
+    onSuccess: (data) => {
+      setEmailToken(data.token);
+      verificationTimer.stop();
+      setStep("password");
+    },
+  });
+
+  const resetPasswordMutation = useMutation({
+    mutationFn: (input: ResetPasswordRequestDto) => {
+      if (emailToken === null) {
+        throw new Error("이메일 인증 토큰이 없습니다.");
+      }
+      return resetPassword(emailToken, input);
+    },
+    onSuccess: () => {
+      void navigate("/login");
+    },
+  });
+
+  const sendPasswordResetMailApiError = getSendPasswordResetMailErrorMessage(
+    sendPasswordResetMailMutation.error,
+  );
+  const emailTokenApiError = getEmailTokenErrorMessage(
+    getEmailTokenMutation.error,
+  );
+  const resetPasswordApiError = getResetPasswordErrorMessage(
+    resetPasswordMutation.error,
+  );
 
   const isSubmitDisabled =
     step === "email"
-      ? !email.trim()
+      ? !email.trim() || sendPasswordResetMailMutation.isPending
       : step === "code"
-        ? !verificationTimer.isRunning || verificationCode.length !== 6
-        : !password || !passwordConfirm || password !== passwordConfirm;
+        ? !verificationTimer.isRunning ||
+          verificationCode.length !== 6 ||
+          getEmailTokenMutation.isPending
+        : !password ||
+          !passwordConfirm ||
+          password !== passwordConfirm ||
+          resetPasswordMutation.isPending;
 
   const handleBack = () => {
     if (step === "password") {
@@ -56,34 +151,35 @@ export const PasswordReset = () => {
     if (isSubmitDisabled) return;
 
     if (step === "email") {
-      if (
-        !EmailPasswordResetRequestDtoSchema.safeParse({ email: email.trim() })
-          .success
-      ) {
+      const result = EmailPasswordResetRequestDtoSchema.safeParse({
+        email: email.trim(),
+      });
+
+      if (!result.success) {
         setEmailError("올바른 이메일 형식이 아닙니다.");
         return;
       }
 
       setEmailError("");
-      setVerificationCode("");
-      verificationTimer.reset();
-      setStep("code");
+      sendPasswordResetMailMutation.reset();
+      sendPasswordResetMailMutation.mutate(result.data);
       return;
     }
 
     if (step === "code") {
-      if (
-        !VerifyMailRequestDtoSchema.safeParse({
-          email: email.trim(),
-          code: verificationCode,
-        }).success
-      ) {
+      const result = VerifyMailRequestDtoSchema.safeParse({
+        email: email.trim(),
+        code: verificationCode,
+      });
+
+      if (!result.success) {
         setVerificationCodeError("인증 코드가 올바르지 않습니다.");
         return;
       }
 
       setVerificationCodeError("");
-      setStep("password");
+      getEmailTokenMutation.reset();
+      getEmailTokenMutation.mutate(result.data);
       return;
     }
 
@@ -100,8 +196,8 @@ export const PasswordReset = () => {
 
     setPasswordError("");
     setPasswordConfirmError("");
-
-    navigate("/login");
+    resetPasswordMutation.reset();
+    resetPasswordMutation.mutate(passwordResult.data);
   };
 
   return (
@@ -116,12 +212,13 @@ export const PasswordReset = () => {
               name="password-reset-email"
               type="email"
               value={email}
-              status={emailError ? "error" : "normal"}
-              description={emailError}
+              status={emailError || sendPasswordResetMailApiError ? "error" : "normal"}
+              description={emailError || sendPasswordResetMailApiError}
               placeholder="example@gmail.com"
               onChange={(event) => {
                 setEmail(event.target.value);
                 setEmailError("");
+                sendPasswordResetMailMutation.reset();
               }}
             />
           </EmailContent>
@@ -142,11 +239,14 @@ export const PasswordReset = () => {
                 onChange={(value) => {
                   setVerificationCode(value);
                   setVerificationCodeError("");
+                  getEmailTokenMutation.reset();
                 }}
               />
             </CodeContent>
-            {verificationCodeError && (
-              <ErrorMessage>{verificationCodeError}</ErrorMessage>
+            {(verificationCodeError || emailTokenApiError) && (
+              <ErrorMessage>
+                {verificationCodeError || emailTokenApiError}
+              </ErrorMessage>
             )}
           </>
         )}
@@ -176,6 +276,7 @@ export const PasswordReset = () => {
                         ? "비밀번호가 일치하지 않습니다."
                         : "",
                     );
+                    resetPasswordMutation.reset();
                   }}
                 />
               </Field>
@@ -187,8 +288,12 @@ export const PasswordReset = () => {
                   name="password-reset-password-confirm"
                   type="password"
                   value={passwordConfirm}
-                  status={passwordConfirmError ? "error" : "normal"}
-                  description={passwordConfirmError}
+                  status={
+                    passwordConfirmError || resetPasswordApiError
+                      ? "error"
+                      : "normal"
+                  }
+                  description={passwordConfirmError || resetPasswordApiError}
                   placeholder="비밀번호를 다시 입력해주세요."
                   adornmentType="icon"
                   onChange={(event) => {
@@ -199,6 +304,7 @@ export const PasswordReset = () => {
                         ? "비밀번호가 일치하지 않습니다."
                         : "",
                     );
+                    resetPasswordMutation.reset();
                   }}
                 />
               </Field>

--- a/apps/frontend-user/src/pages/Auth/SignUp.tsx
+++ b/apps/frontend-user/src/pages/Auth/SignUp.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router";
+import { useMutation } from "@tanstack/react-query";
 import { styled } from "styled-components";
 import { Button } from "../../components/Button";
 import { TextInput } from "../../components/TextInput";
@@ -13,11 +14,59 @@ import {
   SendMailRequestDtoSchema,
   VerifyMailRequestDtoSchema,
 } from "../../type/index";
+import { ApiError, getEmailToken, sendSignUpMail, signUp } from "../../api/api";
+import { setTokens } from "../../api/tokens";
+import { AuthErrorCode } from "@mindseed/api-types";
+import type {
+  CompleteSignupRequestDto,
+  SendMailRequestDto,
+  VerifyMailRequestDto,
+} from "@mindseed/api-types";
 
 type SignUpStep = "email" | "password" | "profile";
 
 const VERIFICATION_VALIDITY_SECONDS = 3 * 60;
 const VERIFICATION_RESEND_DELAY_SECONDS = 30;
+
+function getSendMailErrorMessage(error: Error | null): string {
+  if (error === null) return "";
+  if (error instanceof ApiError) {
+    if (error.errorCode === AuthErrorCode.EMAIL_ALREADY_EXISTS) {
+      return "이미 가입된 이메일입니다.";
+    }
+    if (error.errorCode === AuthErrorCode.EMAIL_RATE_LIMITED) {
+      return "이메일 발송 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.";
+    }
+    if (error.errorCode === AuthErrorCode.VERIFICATION_COOLDOWN) {
+      return "인증 코드를 다시 받으려면 30초 후에 시도해주세요.";
+    }
+  }
+  return "인증 코드 발송 중 오류가 발생했습니다. 다시 시도해주세요.";
+}
+
+function getEmailTokenErrorMessage(error: Error | null): string {
+  if (error === null) return "";
+  if (
+    error instanceof ApiError &&
+    error.errorCode === AuthErrorCode.INVALID_VERIFICATION_CODE
+  ) {
+    return "인증 코드가 올바르지 않습니다.";
+  }
+  return "인증 중 오류가 발생했습니다. 다시 시도해주세요.";
+}
+
+function getSignUpErrorMessage(error: Error | null): string {
+  if (error === null) return "";
+  if (error instanceof ApiError) {
+    if (error.errorCode === AuthErrorCode.EMAIL_ALREADY_EXISTS) {
+      return "이미 가입된 이메일입니다.";
+    }
+    if (error.errorCode === AuthErrorCode.INVALID_SIGN_UP_TOKEN) {
+      return "인증이 만료되었습니다. 처음부터 다시 시도해주세요.";
+    }
+  }
+  return "회원가입 중 오류가 발생했습니다. 다시 시도해주세요.";
+}
 
 export const SignUp = () => {
   const navigate = useNavigate();
@@ -37,12 +86,52 @@ export const SignUp = () => {
   const [nicknameError, setNicknameError] = useState("");
   const [age, setAge] = useState("");
   const [ageError, setAgeError] = useState("");
+  const [emailToken, setEmailToken] = useState<string | null>(null);
+
   const isCodeValid = verificationTimer.isRunning;
   const isEmailStepDisabled =
     !isCodeValid || verificationCode.trim().length !== 6;
   const isPasswordStepDisabled =
     !password || !passwordConfirm || password !== passwordConfirm;
   const isProfileStepDisabled = !nickname.trim() || !age;
+
+  const sendMailMutation = useMutation({
+    mutationFn: (input: SendMailRequestDto) => sendSignUpMail(input),
+    onSuccess: () => {
+      setIsCodeSent(true);
+      setVerificationCode("");
+      verificationTimer.reset();
+      resendTimer.reset();
+    },
+  });
+
+  const getEmailTokenMutation = useMutation({
+    mutationFn: (input: VerifyMailRequestDto) => getEmailToken(input),
+    onSuccess: (data) => {
+      setEmailToken(data.token);
+      verificationTimer.stop();
+      setStep("password");
+    },
+  });
+
+  const signUpMutation = useMutation({
+    mutationFn: (input: CompleteSignupRequestDto) => {
+      if (emailToken === null) {
+        throw new Error("이메일 인증 토큰이 없습니다.");
+      }
+      return signUp(emailToken, input);
+    },
+    onSuccess: (data) => {
+      setTokens(data.accessToken, data.refreshToken);
+      void navigate("/");
+    },
+  });
+
+  const sendMailApiError = getSendMailErrorMessage(sendMailMutation.error);
+  const emailTokenApiError = getEmailTokenErrorMessage(
+    getEmailTokenMutation.error,
+  );
+  const signUpApiError = getSignUpErrorMessage(signUpMutation.error);
 
   const handleBack = () => {
     if (step === "profile") {
@@ -59,17 +148,16 @@ export const SignUp = () => {
   };
 
   const handleSendCode = () => {
-    if (!SendMailRequestDtoSchema.safeParse({ email: email.trim() }).success) {
+    const result = SendMailRequestDtoSchema.safeParse({ email: email.trim() });
+    if (!result.success) {
       setEmailError("올바른 이메일 형식이 아닙니다.");
       return;
     }
 
     setEmailError("");
     setVerificationCodeError("");
-    setIsCodeSent(true);
-    setVerificationCode("");
-    verificationTimer.reset();
-    resendTimer.reset();
+    sendMailMutation.reset();
+    sendMailMutation.mutate(result.data);
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -78,19 +166,18 @@ export const SignUp = () => {
     if (step === "email") {
       if (isEmailStepDisabled) return;
 
-      if (
-        !VerifyMailRequestDtoSchema.safeParse({
-          email: email.trim(),
-          code: verificationCode,
-        }).success
-      ) {
+      const result = VerifyMailRequestDtoSchema.safeParse({
+        email: email.trim(),
+        code: verificationCode,
+      });
+
+      if (!result.success) {
         setVerificationCodeError("인증 코드가 올바르지 않습니다.");
         return;
       }
 
       setVerificationCodeError("");
-      verificationTimer.stop();
-      setStep("password");
+      getEmailTokenMutation.mutate(result.data);
       return;
     }
 
@@ -132,7 +219,7 @@ export const SignUp = () => {
 
     if (!signupResult.success) return;
 
-    navigate("/login");
+    signUpMutation.mutate(signupResult.data);
   };
 
   return (
@@ -157,8 +244,8 @@ export const SignUp = () => {
                     name="signup-email"
                     type="email"
                     value={email}
-                    status={emailError ? "error" : "normal"}
-                    description={emailError}
+                    status={emailError || sendMailApiError ? "error" : "normal"}
+                    description={emailError || sendMailApiError}
                     placeholder="example@gmail.com"
                     onChange={(event) => {
                       setEmail(event.target.value);
@@ -168,6 +255,8 @@ export const SignUp = () => {
                       setIsCodeSent(false);
                       verificationTimer.stop();
                       resendTimer.stop();
+                      sendMailMutation.reset();
+                      getEmailTokenMutation.reset();
                     }}
                   />
 
@@ -176,7 +265,11 @@ export const SignUp = () => {
                       variant="primary"
                       size="medium"
                       label="코드 발송"
-                      disabled={!email.trim() || resendTimer.isRunning}
+                      disabled={
+                        !email.trim() ||
+                        resendTimer.isRunning ||
+                        sendMailMutation.isPending
+                      }
                       onClick={handleSendCode}
                     />
                   </ButtonWrapper>
@@ -188,8 +281,12 @@ export const SignUp = () => {
                 <TextInput
                   name="signup-code"
                   value={verificationCode}
-                  status={verificationCodeError ? "error" : "normal"}
-                  description={verificationCodeError}
+                  status={
+                    verificationCodeError || emailTokenApiError
+                      ? "error"
+                      : "normal"
+                  }
+                  description={verificationCodeError || emailTokenApiError}
                   placeholder={
                     !isCodeSent
                       ? "인증번호 발송 후 입력 가능합니다"
@@ -203,6 +300,7 @@ export const SignUp = () => {
                   onChange={(event) => {
                     setVerificationCode(event.target.value);
                     setVerificationCodeError("");
+                    getEmailTokenMutation.reset();
                   }}
                 />
               </Field>
@@ -291,6 +389,7 @@ export const SignUp = () => {
                   onChange={(event) => {
                     setNickname(event.target.value);
                     setNicknameError("");
+                    signUpMutation.reset();
                   }}
                 />
               </Field>
@@ -300,12 +399,13 @@ export const SignUp = () => {
                 <TextInput
                   name="signup-age"
                   value={age}
-                  status={ageError ? "error" : "normal"}
-                  description={ageError}
+                  status={ageError || signUpApiError ? "error" : "normal"}
+                  description={ageError || signUpApiError}
                   placeholder="나이를 입력해주세요"
                   onChange={(event) => {
                     setAge(event.target.value.replace(/\D/g, "").slice(0, 2));
                     setAgeError("");
+                    signUpMutation.reset();
                   }}
                 />
               </Field>
@@ -322,10 +422,10 @@ export const SignUp = () => {
             showIcon={step !== "profile"}
             disabled={
               step === "email"
-                ? isEmailStepDisabled
+                ? isEmailStepDisabled || getEmailTokenMutation.isPending
                 : step === "password"
                   ? isPasswordStepDisabled
-                  : isProfileStepDisabled
+                  : isProfileStepDisabled || signUpMutation.isPending
             }
           />
           <Links>

--- a/apps/frontend-user/src/pages/Auth/SignUp.tsx
+++ b/apps/frontend-user/src/pages/Auth/SignUp.tsx
@@ -15,6 +15,7 @@ import {
   VerifyMailRequestDtoSchema,
 } from "../../type/index";
 import { ApiError, getEmailToken, sendSignUpMail, signUp } from "../../api/api";
+import { getEmailTokenErrorMessage } from "./authErrors";
 import { setTokens } from "../../api/tokens";
 import { AuthErrorCode } from "@mindseed/api-types";
 import type {
@@ -42,17 +43,6 @@ function getSendMailErrorMessage(error: Error | null): string {
     }
   }
   return "인증 코드 발송 중 오류가 발생했습니다. 다시 시도해주세요.";
-}
-
-function getEmailTokenErrorMessage(error: Error | null): string {
-  if (error === null) return "";
-  if (
-    error instanceof ApiError &&
-    error.errorCode === AuthErrorCode.INVALID_VERIFICATION_CODE
-  ) {
-    return "인증 코드가 올바르지 않습니다.";
-  }
-  return "인증 중 오류가 발생했습니다. 다시 시도해주세요.";
 }
 
 function getSignUpErrorMessage(error: Error | null): string {
@@ -124,6 +114,15 @@ export const SignUp = () => {
     onSuccess: (data) => {
       setTokens(data.accessToken, data.refreshToken);
       void navigate("/");
+    },
+    onError: (error) => {
+      if (
+        error instanceof ApiError &&
+        error.errorCode === AuthErrorCode.INVALID_SIGN_UP_TOKEN
+      ) {
+        setEmailToken(null);
+        setStep("email");
+      }
     },
   });
 
@@ -399,8 +398,8 @@ export const SignUp = () => {
                 <TextInput
                   name="signup-age"
                   value={age}
-                  status={ageError || signUpApiError ? "error" : "normal"}
-                  description={ageError || signUpApiError}
+                  status={ageError ? "error" : "normal"}
+                  description={ageError}
                   placeholder="나이를 입력해주세요"
                   onChange={(event) => {
                     setAge(event.target.value.replace(/\D/g, "").slice(0, 2));
@@ -410,6 +409,7 @@ export const SignUp = () => {
                 />
               </Field>
             </Fields>
+            {signUpApiError && <ErrorMessage>{signUpApiError}</ErrorMessage>}
           </>
         )}
 
@@ -501,6 +501,13 @@ const EmailRow = styled.div`
 const ButtonWrapper = styled.div`
   width: 108px;
   flex-shrink: 0;
+`;
+
+const ErrorMessage = styled.p`
+  margin-top: 0.5rem;
+  color: ${COLORS.state.error};
+  ${TEXT_STYLE.body.ti};
+  text-align: center;
 `;
 
 const BottomArea = styled.div`

--- a/apps/frontend-user/src/pages/Auth/authErrors.ts
+++ b/apps/frontend-user/src/pages/Auth/authErrors.ts
@@ -1,0 +1,13 @@
+import { ApiError } from "../../api/api";
+import { AuthErrorCode } from "@mindseed/api-types";
+
+export function getEmailTokenErrorMessage(error: Error | null): string {
+  if (error === null) return "";
+  if (
+    error instanceof ApiError &&
+    error.errorCode === AuthErrorCode.INVALID_VERIFICATION_CODE
+  ) {
+    return "인증 코드가 올바르지 않습니다.";
+  }
+  return "인증 중 오류가 발생했습니다. 다시 시도해주세요.";
+}

--- a/apps/frontend-user/src/pages/Community/Community.tsx
+++ b/apps/frontend-user/src/pages/Community/Community.tsx
@@ -41,7 +41,6 @@ export const CommunityMainPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchText, setSearchText] = useState("");
   const [searchKeyword, setSearchKeyword] = useState("");
-  const [likedPosts, setLikedPosts] = useState<Record<number, boolean>>({});
   const [activeSort, setActiveSort] = useState<CommunitySort>("최신순");
   const [isSortOpen, setIsSortOpen] = useState(false);
   const categoryParam = searchParams.get("category");
@@ -77,9 +76,6 @@ export const CommunityMainPage = () => {
         (token) => setPostLike(token, postId, { liked }),
         navigate,
       ),
-    onError: (_, { postId, liked }) => {
-      setLikedPosts((current) => ({ ...current, [postId]: !liked }));
-    },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: ["posts"] });
     },
@@ -115,9 +111,7 @@ export const CommunityMainPage = () => {
   };
 
   const handleLikeClick = (post: PostDto) => {
-    const newLiked = !(likedPosts[post.id] ?? post.isLiked);
-    setLikedPosts((current) => ({ ...current, [post.id]: newLiked }));
-    setPostLikeMutation.mutate({ postId: post.id, liked: newLiked });
+    setPostLikeMutation.mutate({ postId: post.id, liked: !post.isLiked });
   };
 
   return (
@@ -162,7 +156,7 @@ export const CommunityMainPage = () => {
               content={post.content}
               attachments={post.attachments}
               createdAt={post.createdAt}
-              isLiked={likedPosts[post.id] ?? post.isLiked}
+              isLiked={post.isLiked}
               onClick={() => navigate(getCommunityPostPath(post.id))}
               onLikeClick={() => handleLikeClick(post)}
             />

--- a/apps/frontend-user/src/pages/Community/Community.tsx
+++ b/apps/frontend-user/src/pages/Community/Community.tsx
@@ -77,7 +77,10 @@ export const CommunityMainPage = () => {
         (token) => setPostLike(token, postId, { liked }),
         navigate,
       ),
-    onSuccess: () => {
+    onError: (_, { postId, liked }) => {
+      setLikedPosts((current) => ({ ...current, [postId]: !liked }));
+    },
+    onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: ["posts"] });
     },
   });

--- a/apps/frontend-user/src/pages/Community/Community.tsx
+++ b/apps/frontend-user/src/pages/Community/Community.tsx
@@ -1,118 +1,31 @@
 import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { styled } from "styled-components";
 import { Category } from "../../components/Category";
-import { FilterButton } from "../../components/community/FilterButton";
-import { FloatingButton } from "../../components/community/FloatingButton";
-import { Banner } from "../../components/community/Banner";
-import { BottomSheet } from "../../components/community/BottomSheet";
-import { Post } from "../../components/community/Post";
+import { FilterButton } from "../../components/Community/FilterButton";
+import { FloatingButton } from "../../components/Community/FloatingButton";
+import { Banner } from "../../components/Community/Banner";
+import { BottomSheet } from "../../components/Community/BottomSheet";
+import { Post } from "../../components/Community/Post";
 import { SearchBar } from "../../components/SearchBar";
 import { COLORS } from "../../style/colors";
 import { TEXT_STYLE } from "../../style/typography";
-import { PostWithCommentsSchema } from "../../type/index";
-import type { CommunityPost, PostCategory } from "../../type/index";
+import type { PostCategory } from "../../type/index";
+import type { PostDto } from "../../type/index";
+import { getPosts, setPostLike } from "../../api/api";
+import { callAuthenticated } from "../../api/callAuthenticated";
+import { POST_CATEGORIES } from "../../postCategory";
 
-type CommunityCategory = "all" | PostCategory | "other";
+type CommunityCategory = "ALL" | PostCategory;
 
 const COMMUNITY_CATEGORIES: ReadonlyArray<{
   value: CommunityCategory;
   label: string;
-}> = [
-  { value: "all", label: "전체" },
-  { value: "dummy1", label: "고민상담" },
-  { value: "dummy2", label: "일상" },
-  { value: "dummy3", label: "문의" },
-  { value: "other", label: "기타" },
-];
+}> = [{ value: "ALL", label: "전체" }, ...POST_CATEGORIES];
 
 const COMMUNITY_SORT_OPTIONS = ["최신순", "인기순", "추천순"] as const;
 type CommunitySort = (typeof COMMUNITY_SORT_OPTIONS)[number];
-
-const COMMUNITY_POSTS: CommunityPost[] = [
-  {
-    id: 1,
-    content: "요즘 마음이 복잡한데 어떻게 정리하면 좋을까요?",
-    category: "dummy1",
-    author: { nickname: "마음지기" },
-    attachments: [],
-    likeCount: 12,
-    isOwner: true,
-    isLiked: false,
-    createdAt: "2026-07-28T09:00:00.000Z",
-    updatedAt: "2026-07-28T09:00:00.000Z",
-    comments: [
-      {
-        type: "active",
-        id: 1,
-        content: "작성자 댓글입니다.",
-        author: { nickname: "마음지기" },
-        createdAt: "2026-07-28T09:10:00.000Z",
-        updatedAt: "2026-07-28T09:10:00.000Z",
-      },
-      {
-        type: "active",
-        id: 2,
-        content: "천천히 하나씩 적어보는 건 어떨까요?",
-        author: { nickname: "새싹이" },
-        createdAt: "2026-07-28T09:20:00.000Z",
-        updatedAt: "2026-07-28T09:20:00.000Z",
-      },
-    ],
-  },
-  {
-    id: 2,
-    content: "오늘은 산책하면서 기분 전환을 했어요.",
-    category: "dummy2",
-    author: { nickname: "초록이" },
-    attachments: [],
-    likeCount: 8,
-    isOwner: false,
-    isLiked: true,
-    createdAt: "2026-07-27T10:00:00.000Z",
-    updatedAt: "2026-07-27T10:00:00.000Z",
-    comments: [],
-  },
-  {
-    id: 3,
-    content: "자가진단 결과는 어디에서 다시 확인할 수 있나요?",
-    category: "dummy3",
-    author: { nickname: "푸른콩" },
-    attachments: [],
-    likeCount: 5,
-    isOwner: false,
-    isLiked: false,
-    createdAt: "2026-07-26T11:00:00.000Z",
-    updatedAt: "2026-07-26T11:00:00.000Z",
-    comments: [],
-  },
-  {
-    id: 4,
-    content: "잠들기 전에 어떤 생각을 하면 마음이 편해질까요?",
-    category: "dummy1",
-    author: { nickname: "나무늘보" },
-    attachments: [],
-    likeCount: 18,
-    isOwner: false,
-    isLiked: false,
-    createdAt: "2026-07-25T12:00:00.000Z",
-    updatedAt: "2026-07-25T12:00:00.000Z",
-    comments: [],
-  },
-  {
-    id: 5,
-    content: "작은 화분에 새싹이 올라왔어요!",
-    category: "dummy2",
-    author: { nickname: "햇살이" },
-    attachments: [],
-    likeCount: 21,
-    isOwner: false,
-    isLiked: true,
-    createdAt: "2026-07-24T13:00:00.000Z",
-    updatedAt: "2026-07-24T13:00:00.000Z",
-    comments: [],
-  },
-].map((post) => PostWithCommentsSchema.parse(post));
 
 const getCommunityPostPath = (postId: string | number) =>
   `/community/${postId}`;
@@ -124,7 +37,7 @@ const isCommunityCategory = (
 
 export const CommunityMainPage = () => {
   const navigate = useNavigate();
-  const posts = COMMUNITY_POSTS;
+  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchText, setSearchText] = useState("");
   const [searchKeyword, setSearchKeyword] = useState("");
@@ -134,17 +47,51 @@ export const CommunityMainPage = () => {
   const categoryParam = searchParams.get("category");
   const activeCategory = isCommunityCategory(categoryParam)
     ? categoryParam
-    : "all";
+    : "ALL";
+
+  const postsQuery = useQuery({
+    queryKey: [
+      "posts",
+      { category: activeCategory === "ALL" ? undefined : activeCategory },
+    ],
+    queryFn: ({ signal }) =>
+      callAuthenticated(
+        (token) =>
+          getPosts(
+            token,
+            {
+              limit: 50,
+              orderBy: "createdAt",
+              orderDirection: "desc",
+              category: activeCategory === "ALL" ? undefined : activeCategory,
+            },
+            { signal },
+          ),
+        navigate,
+      ),
+  });
+
+  const setPostLikeMutation = useMutation({
+    mutationFn: ({ postId, liked }: { postId: number; liked: boolean }) =>
+      callAuthenticated(
+        (token) => setPostLike(token, postId, { liked }),
+        navigate,
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["posts"] });
+    },
+  });
+
+  const posts: PostDto[] = postsQuery.data?.items ?? [];
+
   const normalizedKeyword = searchKeyword.trim().toLowerCase();
   const filteredPosts = posts.filter((post) => {
-    const matchesCategory =
-      activeCategory === "all" || post.category === activeCategory;
     const matchesKeyword =
       !normalizedKeyword ||
       post.content.toLowerCase().includes(normalizedKeyword) ||
       post.author.nickname.toLowerCase().includes(normalizedKeyword);
 
-    return matchesCategory && matchesKeyword;
+    return matchesKeyword;
   });
   const sortedPosts = [...filteredPosts].sort((first, second) => {
     if (activeSort === "최신순") {
@@ -161,14 +108,13 @@ export const CommunityMainPage = () => {
   });
 
   const handleCategoryChange = (category: CommunityCategory) => {
-    setSearchParams(category === "all" ? {} : { category });
+    setSearchParams(category === "ALL" ? {} : { category });
   };
 
-  const handleLikeClick = (post: CommunityPost) => {
-    setLikedPosts((current) => ({
-      ...current,
-      [post.id]: !(current[post.id] ?? post.isLiked),
-    }));
+  const handleLikeClick = (post: PostDto) => {
+    const newLiked = !(likedPosts[post.id] ?? post.isLiked);
+    setLikedPosts((current) => ({ ...current, [post.id]: newLiked }));
+    setPostLikeMutation.mutate({ postId: post.id, liked: newLiked });
   };
 
   return (

--- a/apps/frontend-user/src/pages/Community/PostDetail.tsx
+++ b/apps/frontend-user/src/pages/Community/PostDetail.tsx
@@ -1,119 +1,75 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { styled } from "styled-components";
-import { Comment, CommentInput } from "../../components/community/Comment";
-import { BottomSheet } from "../../components/community/BottomSheet";
-import { CommentButton } from "../../components/community/CommentButton";
-import { LikeButton } from "../../components/community/LikeButton";
-import { Post } from "../../components/community/Post";
+import { Comment, CommentInput } from "../../components/Community/Comment";
+import { BottomSheet } from "../../components/Community/BottomSheet";
+import { CommentButton } from "../../components/Community/CommentButton";
+import { LikeButton } from "../../components/Community/LikeButton";
+import { Post } from "../../components/Community/Post";
 import { TopBar } from "../../components/TopBar";
-import { DeleteModal } from "../../components/community/DeleteModal";
+import { DeleteModal } from "../../components/Community/DeleteModal";
+import { ReportModal } from "../../components/Community/ReportModal";
 import { COLORS } from "../../style/colors";
 import { TEXT_STYLE } from "../../style/typography";
-import {
-  ActiveCommentDtoSchema,
-  PostWithCommentsSchema,
-} from "../../type/index";
+import { ActiveCommentDtoSchema } from "../../type/index";
 import type { CommunityPost } from "../../type/index";
+import type { CreateCommentRequestDto } from "@mindseed/api-types";
+import { getPost, setPostLike, deletePost, createComment, updateComment, deleteComment, createPostReport, createCommentReport } from "../../api/api";
+import { callAuthenticated } from "../../api/callAuthenticated";
 
 const COMMUNITY_AUTHOR_NICKNAME = "마음지기";
 
 type DeleteTarget = { type: "post" } | { type: "comment"; commentId: number };
-
-const COMMUNITY_POSTS: CommunityPost[] = [
-  {
-    id: 1,
-    content: "요즘 마음이 복잡한데 어떻게 정리하면 좋을까요?",
-    category: "dummy1",
-    author: { nickname: COMMUNITY_AUTHOR_NICKNAME },
-    attachments: [],
-    likeCount: 12,
-    isOwner: true,
-    isLiked: false,
-    createdAt: "2026-07-28T09:00:00.000Z",
-    updatedAt: "2026-07-28T09:00:00.000Z",
-    comments: [
-      {
-        type: "active",
-        id: 1,
-        content: "작성자 댓글입니다.",
-        author: { nickname: COMMUNITY_AUTHOR_NICKNAME },
-        createdAt: "2026-07-28T09:10:00.000Z",
-        updatedAt: "2026-07-28T09:10:00.000Z",
-      },
-      {
-        type: "active",
-        id: 2,
-        content: "천천히 하나씩 적어보는 건 어떨까요?",
-        author: { nickname: "새싹이" },
-        createdAt: "2026-07-28T09:20:00.000Z",
-        updatedAt: "2026-07-28T09:20:00.000Z",
-      },
-    ],
-  },
-  {
-    id: 2,
-    content: "오늘은 산책하면서 기분 전환을 했어요.",
-    category: "dummy2",
-    author: { nickname: "초록이" },
-    attachments: [],
-    likeCount: 8,
-    isOwner: false,
-    isLiked: true,
-    createdAt: "2026-07-27T10:00:00.000Z",
-    updatedAt: "2026-07-27T10:00:00.000Z",
-    comments: [],
-  },
-  {
-    id: 3,
-    content: "자가진단 결과는 어디에서 다시 확인할 수 있나요?",
-    category: "dummy3",
-    author: { nickname: "푸른콩" },
-    attachments: [],
-    likeCount: 5,
-    isOwner: false,
-    isLiked: false,
-    createdAt: "2026-07-26T11:00:00.000Z",
-    updatedAt: "2026-07-26T11:00:00.000Z",
-    comments: [],
-  },
-  {
-    id: 4,
-    content: "잠들기 전에 어떤 생각을 하면 마음이 편해질까요?",
-    category: "dummy1",
-    author: { nickname: "나무늘보" },
-    attachments: [],
-    likeCount: 18,
-    isOwner: false,
-    isLiked: false,
-    createdAt: "2026-07-25T12:00:00.000Z",
-    updatedAt: "2026-07-25T12:00:00.000Z",
-    comments: [],
-  },
-  {
-    id: 5,
-    content: "작은 화분에 새싹이 올라왔어요!",
-    category: "dummy2",
-    author: { nickname: "햇살이" },
-    attachments: [],
-    likeCount: 21,
-    isOwner: false,
-    isLiked: true,
-    createdAt: "2026-07-24T13:00:00.000Z",
-    updatedAt: "2026-07-24T13:00:00.000Z",
-    comments: [],
-  },
-].map((post) => PostWithCommentsSchema.parse(post));
+type ReportTarget = { type: "post" } | { type: "comment"; commentId: number };
 
 export const PostDetailPage = () => {
   const { postId } = useParams();
-  const post = COMMUNITY_POSTS.find((item) => String(item.id) === postId);
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
-  return <PostDetailContent key={postId} post={post} />;
+  const postQuery = useQuery({
+    queryKey: ["posts", Number(postId)],
+    queryFn: ({ signal }) =>
+      callAuthenticated(
+        (token) => getPost(token, Number(postId), { signal }),
+        navigate,
+      ),
+    enabled: !!postId,
+  });
+
+  const deletePostMutation = useMutation({
+    mutationFn: () =>
+      callAuthenticated(
+        (token) => deletePost(token, Number(postId)),
+        navigate,
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["posts"] });
+      navigate("/community", { replace: true });
+    },
+  });
+
+  if (postQuery.isLoading) return null;
+
+  return (
+    <PostDetailContent
+      key={postId}
+      post={postQuery.data}
+      onDeletePost={() => deletePostMutation.mutate()}
+    />
+  );
 };
 
-const PostDetailContent = ({ post }: { post?: CommunityPost }) => {
+const PostDetailContent = ({
+  post,
+  onDeletePost,
+}: {
+  post?: CommunityPost;
+  onDeletePost: () => void;
+}) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const commentInputRef = useRef<HTMLDivElement>(null);
   const [comment, setComment] = useState("");
   const [isCommentMode, setIsCommentMode] = useState(false);
@@ -125,6 +81,7 @@ const PostDetailContent = ({ post }: { post?: CommunityPost }) => {
   const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
   const [editingComment, setEditingComment] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+  const [reportTarget, setReportTarget] = useState<ReportTarget | null>(null);
   const originalEditingComment = comments.find(
     (item) => item.id === editingCommentId && item.type === "active",
   );
@@ -133,6 +90,118 @@ const PostDetailContent = ({ post }: { post?: CommunityPost }) => {
     originalEditingComment?.type === "active" &&
     trimmedEditingComment === originalEditingComment.content.trim();
   const isEditDisabled = !trimmedEditingComment || isEditingCommentUnchanged;
+
+  const createCommentMutation = useMutation({
+    mutationFn: (input: CreateCommentRequestDto) =>
+      callAuthenticated(
+        (token) => createComment(token, post!.id, input),
+        navigate,
+      ),
+    onSuccess: (data, variables) => {
+      const now = new Date().toISOString();
+      const result = ActiveCommentDtoSchema.safeParse({
+        type: "active",
+        id: data.id,
+        content: variables.content,
+        author: { nickname: variables.nickname },
+        isOwner: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      if (result.success) {
+        setComments((items) => [...items, result.data]);
+      }
+      setComment("");
+      setIsCommentMode(false);
+    },
+  });
+
+  const updateCommentMutation = useMutation({
+    mutationFn: ({
+      commentId,
+      content,
+    }: {
+      commentId: number;
+      content: string;
+    }) =>
+      callAuthenticated(
+        (token) => updateComment(token, post!.id, commentId, { content }),
+        navigate,
+      ),
+    onSuccess: (_, variables) => {
+      setComments((items) =>
+        items.map((item) =>
+          item.id === variables.commentId && item.type === "active"
+            ? { ...item, content: variables.content }
+            : item,
+        ),
+      );
+      setEditingCommentId(null);
+      setEditingComment("");
+    },
+  });
+
+  const deleteCommentMutation = useMutation({
+    mutationFn: (commentId: number) =>
+      callAuthenticated(
+        (token) => deleteComment(token, post!.id, commentId),
+        navigate,
+      ),
+    onSuccess: (_, commentId) => {
+      setComments((items) =>
+        items.map((item) =>
+          item.id === commentId
+            ? {
+                type: "deleted" as const,
+                id: item.id,
+                deletionType: "author" as const,
+                createdAt: item.createdAt,
+                updatedAt: item.updatedAt,
+              }
+            : item,
+        ),
+      );
+      setEditingCommentId(null);
+      setEditingComment("");
+      setDeleteTarget(null);
+    },
+  });
+
+  const createPostReportMutation = useMutation({
+    mutationFn: (reason: string) =>
+      callAuthenticated(
+        (token) => createPostReport(token, { postId: post!.id, reason }),
+        navigate,
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["posts"] });
+      setReportTarget(null);
+      navigate("/community", { replace: true });
+    },
+  });
+
+  const createCommentReportMutation = useMutation({
+    mutationFn: ({ commentId, reason }: { commentId: number; reason: string }) =>
+      callAuthenticated(
+        (token) => createCommentReport(token, { commentId, reason }),
+        navigate,
+      ),
+    onSuccess: (_, variables) => {
+      setComments((items) => items.filter((item) => item.id !== variables.commentId));
+      setReportTarget(null);
+    },
+  });
+
+  const setPostLikeMutation = useMutation({
+    mutationFn: (liked: boolean) =>
+      callAuthenticated(
+        (token) => setPostLike(token, post!.id, { liked }),
+        navigate,
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["posts"] });
+    },
+  });
 
   useEffect(() => {
     if (!isCommentMode && editingCommentId === null) return;
@@ -154,59 +223,49 @@ const PostDetailContent = ({ post }: { post?: CommunityPost }) => {
     event.preventDefault();
     const trimmedComment = comment.trim();
     if (!trimmedComment || !post) return;
-
-    const now = new Date().toISOString();
-    const result = ActiveCommentDtoSchema.safeParse({
-      type: "active",
-      id: comments.reduce((maxId, item) => Math.max(maxId, item.id), 0) + 1,
+    createCommentMutation.mutate({
+      nickname: COMMUNITY_AUTHOR_NICKNAME,
       content: trimmedComment,
-      author: { nickname: COMMUNITY_AUTHOR_NICKNAME },
-      createdAt: now,
-      updatedAt: now,
     });
-
-    if (!result.success) return;
-
-    setComments((items) => [...items, result.data]);
-    setComment("");
-    setIsCommentMode(false);
   };
 
   const handleLikeClick = () => {
-    setIsLiked(!isLiked);
-    setLikeCount((count) => Math.max(0, count + (isLiked ? -1 : 1)));
+    const newLiked = !isLiked;
+    setIsLiked(newLiked);
+    setLikeCount((count) => Math.max(0, count + (newLiked ? 1 : -1)));
+    setPostLikeMutation.mutate(newLiked);
   };
 
   const handleEditSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (isEditDisabled || editingCommentId === null) return;
-
-    setComments((items) =>
-      items.map((item) =>
-        item.id === editingCommentId && item.type === "active"
-          ? { ...item, content: trimmedEditingComment }
-          : item,
-      ),
-    );
-    setEditingCommentId(null);
-    setEditingComment("");
+    updateCommentMutation.mutate({
+      commentId: editingCommentId,
+      content: trimmedEditingComment,
+    });
   };
 
   const handleDeleteConfirm = () => {
     if (!deleteTarget) return;
 
     if (deleteTarget.type === "comment") {
-      setComments((items) =>
-        items.filter((item) => item.id !== deleteTarget.commentId),
-      );
-      setEditingCommentId(null);
-      setEditingComment("");
-      setDeleteTarget(null);
+      deleteCommentMutation.mutate(deleteTarget.commentId);
       return;
     }
 
     setDeleteTarget(null);
-    navigate("/community", { replace: true });
+    onDeletePost();
+  };
+
+  const handleReportConfirm = (reason: string) => {
+    if (!reportTarget) return;
+
+    if (reportTarget.type === "comment") {
+      createCommentReportMutation.mutate({ commentId: reportTarget.commentId, reason });
+      return;
+    }
+
+    createPostReportMutation.mutate(reason);
   };
 
   if (!post) {
@@ -256,7 +315,7 @@ const PostDetailContent = ({ post }: { post?: CommunityPost }) => {
             <CommentInput
               value={comment}
               buttonText="등록"
-              disabled={!comment.trim()}
+              disabled={!comment.trim() || createCommentMutation.isPending}
               onChange={(event) => setComment(event.target.value)}
               onSubmit={handleSubmit}
               autoFocus
@@ -270,14 +329,13 @@ const PostDetailContent = ({ post }: { post?: CommunityPost }) => {
               <CommentInput
                 value={editingComment}
                 buttonText="수정"
-                disabled={isEditDisabled}
+                disabled={isEditDisabled || updateCommentMutation.isPending}
                 onChange={(event) => setEditingComment(event.target.value)}
                 onSubmit={handleEditSubmit}
                 autoFocus
               />
             </CommentInputArea>
-          ) : item.type === "active" &&
-            item.author.nickname === COMMUNITY_AUTHOR_NICKNAME ? (
+          ) : item.type === "active" && item.isOwner ? (
             <Comment
               key={item.id}
               comment={item}
@@ -306,7 +364,12 @@ const PostDetailContent = ({ post }: { post?: CommunityPost }) => {
         <BottomSheet
           variant="commentMore"
           isClose={false}
-          onClick={() => setMoreCommentId(null)}
+          onClick={(menu) => {
+            if (menu === "report") {
+              setReportTarget({ type: "comment", commentId: moreCommentId });
+            }
+            setMoreCommentId(null);
+          }}
           onClose={() => setMoreCommentId(null)}
         />
       )}
@@ -340,6 +403,10 @@ const PostDetailContent = ({ post }: { post?: CommunityPost }) => {
             if (menu === "copyLink") {
               void navigator.clipboard?.writeText(window.location.href);
             }
+
+            if (menu === "report") {
+              setReportTarget({ type: "post" });
+            }
           }}
           onClose={() => setIsPostMenuOpen(false)}
         />
@@ -349,6 +416,13 @@ const PostDetailContent = ({ post }: { post?: CommunityPost }) => {
         isOpen={deleteTarget !== null}
         onConfirm={handleDeleteConfirm}
         onCancel={() => setDeleteTarget(null)}
+      />
+
+      <ReportModal
+        isOpen={reportTarget !== null}
+        isPending={createPostReportMutation.isPending || createCommentReportMutation.isPending}
+        onConfirm={handleReportConfirm}
+        onCancel={() => setReportTarget(null)}
       />
     </Page>
   );

--- a/apps/frontend-user/src/pages/Community/PostDetail.tsx
+++ b/apps/frontend-user/src/pages/Community/PostDetail.tsx
@@ -51,6 +51,12 @@ export const PostDetailPage = () => {
   });
 
   if (postQuery.isLoading) return null;
+  if (postQuery.isError) return (
+    <Page>
+      <TopBar onBackClick={() => navigate("/community")} />
+      <NotFound>게시글을 불러오지 못했습니다.</NotFound>
+    </Page>
+  );
 
   return (
     <PostDetailContent
@@ -110,6 +116,8 @@ const PostDetailContent = ({
       });
       if (result.success) {
         setComments((items) => [...items, result.data]);
+      } else {
+        void queryClient.invalidateQueries({ queryKey: ["posts", post!.id] });
       }
       setComment("");
       setIsCommentMode(false);
@@ -198,7 +206,11 @@ const PostDetailContent = ({
         (token) => setPostLike(token, post!.id, { liked }),
         navigate,
       ),
-    onSuccess: () => {
+    onError: (_, liked) => {
+      setIsLiked(!liked);
+      setLikeCount((count) => Math.max(0, count + (liked ? -1 : 1)));
+    },
+    onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: ["posts"] });
     },
   });

--- a/apps/frontend-user/src/pages/Community/PostWrite.tsx
+++ b/apps/frontend-user/src/pages/Community/PostWrite.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import { PostWithCommentsSchema } from "../../type/index";
 import type {
   CommunityPost,
   PictureDto,
@@ -7,6 +6,7 @@ import type {
   PostContent,
 } from "../../type/index";
 import { useNavigate, useParams } from "react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { styled } from "styled-components";
 import { Category } from "../../components/Category";
 import { PictureList } from "../../components/Picture";
@@ -14,114 +14,51 @@ import { TopBar } from "../../components/TopBar";
 import { AddIcon } from "../../components/Icons/AddIcon";
 import { COLORS } from "../../style/colors";
 import { TEXT_STYLE } from "../../style/typography";
+import {
+  getPost,
+  createPost,
+  updatePost,
+  beginAttachmentUpload,
+  confirmAttachmentUpload,
+} from "../../api/api";
+import { callAuthenticated } from "../../api/callAuthenticated";
+import { getAccessToken } from "../../api/tokens";
+import { POST_CATEGORIES } from "../../postCategory";
 
 const COMMUNITY_AUTHOR_NICKNAME = "마음지기";
 
-type WriteCategory = PostCategory | "other";
+type WriteCategory = PostCategory;
 
-const WRITE_CATEGORIES: ReadonlyArray<{
-  value: WriteCategory;
-  label: string;
-}> = [
-  { value: "dummy1", label: "고민상담" },
-  { value: "dummy2", label: "일상" },
-  { value: "dummy3", label: "문의" },
-  { value: "other", label: "기타" },
-];
-
-const COMMUNITY_POSTS: CommunityPost[] = [
-  {
-    id: 1,
-    content: "요즘 마음이 복잡한데 어떻게 정리하면 좋을까요?",
-    category: "dummy1",
-    author: { nickname: COMMUNITY_AUTHOR_NICKNAME },
-    attachments: [],
-    likeCount: 12,
-    isOwner: true,
-    isLiked: false,
-    createdAt: "2026-07-28T09:00:00.000Z",
-    updatedAt: "2026-07-28T09:00:00.000Z",
-    comments: [
-      {
-        type: "active",
-        id: 1,
-        content: "작성자 댓글입니다.",
-        author: { nickname: COMMUNITY_AUTHOR_NICKNAME },
-        createdAt: "2026-07-28T09:10:00.000Z",
-        updatedAt: "2026-07-28T09:10:00.000Z",
-      },
-      {
-        type: "active",
-        id: 2,
-        content: "천천히 하나씩 적어보는 건 어떨까요?",
-        author: { nickname: "새싹이" },
-        createdAt: "2026-07-28T09:20:00.000Z",
-        updatedAt: "2026-07-28T09:20:00.000Z",
-      },
-    ],
-  },
-  {
-    id: 2,
-    content: "오늘은 산책하면서 기분 전환을 했어요.",
-    category: "dummy2",
-    author: { nickname: "초록이" },
-    attachments: [],
-    likeCount: 8,
-    isOwner: false,
-    isLiked: true,
-    createdAt: "2026-07-27T10:00:00.000Z",
-    updatedAt: "2026-07-27T10:00:00.000Z",
-    comments: [],
-  },
-  {
-    id: 3,
-    content: "자가진단 결과는 어디에서 다시 확인할 수 있나요?",
-    category: "dummy3",
-    author: { nickname: "푸른콩" },
-    attachments: [],
-    likeCount: 5,
-    isOwner: false,
-    isLiked: false,
-    createdAt: "2026-07-26T11:00:00.000Z",
-    updatedAt: "2026-07-26T11:00:00.000Z",
-    comments: [],
-  },
-  {
-    id: 4,
-    content: "잠들기 전에 어떤 생각을 하면 마음이 편해질까요?",
-    category: "dummy1",
-    author: { nickname: "나무늘보" },
-    attachments: [],
-    likeCount: 18,
-    isOwner: false,
-    isLiked: false,
-    createdAt: "2026-07-25T12:00:00.000Z",
-    updatedAt: "2026-07-25T12:00:00.000Z",
-    comments: [],
-  },
-  {
-    id: 5,
-    content: "작은 화분에 새싹이 올라왔어요!",
-    category: "dummy2",
-    author: { nickname: "햇살이" },
-    attachments: [],
-    likeCount: 21,
-    isOwner: false,
-    isLiked: true,
-    createdAt: "2026-07-24T13:00:00.000Z",
-    updatedAt: "2026-07-24T13:00:00.000Z",
-    comments: [],
-  },
-].map((post) => PostWithCommentsSchema.parse(post));
+const WRITE_CATEGORIES = POST_CATEGORIES;
 
 const getCommunityPostPath = (postId: string | number) =>
   `/community/${postId}`;
 
+type NewAttachment = {
+  key: number;
+  localUrl: string;
+  attachmentId: number | null;
+};
+
 export const PostWritePage = () => {
   const { postId } = useParams();
-  const post = COMMUNITY_POSTS.find((item) => String(item.id) === postId);
+  const navigate = useNavigate();
 
-  return <PostWriteContent key={postId} postId={postId} post={post} />;
+  const postQuery = useQuery({
+    queryKey: ["posts", Number(postId)],
+    queryFn: ({ signal }) =>
+      callAuthenticated(
+        (token) => getPost(token, Number(postId), { signal }),
+        navigate,
+      ),
+    enabled: postId !== undefined,
+  });
+
+  if (postId !== undefined && !postQuery.data) return null;
+
+  return (
+    <PostWriteContent key={postId} postId={postId} post={postQuery.data} />
+  );
 };
 
 const PostWriteContent = ({
@@ -132,51 +69,135 @@ const PostWriteContent = ({
   post?: CommunityPost;
 }) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const keyCounterRef = useRef(0);
+  const localUrlsRef = useRef<string[]>([]);
   const isEdit = post !== undefined;
   const [category, setCategory] = useState<WriteCategory>(
     post?.category ?? WRITE_CATEGORIES[0].value,
   );
   const [content, setContent] = useState<PostContent>(post?.content ?? "");
-  const [imageUrls, setImageUrls] = useState<string[]>([]);
-  const imageUrlsRef = useRef<string[]>([]);
+  const [newAttachments, setNewAttachments] = useState<NewAttachment[]>([]);
   const displayNickname = post?.author.nickname ?? COMMUNITY_AUTHOR_NICKNAME;
   const pictures: PictureDto[] = [
     ...(post?.attachments ?? []),
-    ...imageUrls.map((url, index) => ({ id: -(index + 1), url })),
+    ...newAttachments.map((a) => ({ id: a.attachmentId ?? a.key, url: a.localUrl })),
   ];
   const trimmedContent = content.trim();
+  const hasUploadPending = newAttachments.some((a) => a.attachmentId === null);
   const isPostUnchanged =
     post !== undefined &&
     category === post.category &&
     trimmedContent === post.content.trim() &&
-    imageUrls.length === 0;
-  const isCompleteDisabled = !trimmedContent || isPostUnchanged;
+    newAttachments.length === 0;
+  const isCompleteDisabled =
+    !trimmedContent || isPostUnchanged || hasUploadPending;
+
+  const createPostMutation = useMutation({
+    mutationFn: () =>
+      callAuthenticated(
+        (token) =>
+          createPost(token, {
+            content: trimmedContent,
+            category,
+            nickname: displayNickname,
+            attachmentIds: newAttachments
+              .filter((a) => a.attachmentId !== null)
+              .map((a) => a.attachmentId!),
+          }),
+        navigate,
+      ),
+    onSuccess: (data) => {
+      void queryClient.invalidateQueries({ queryKey: ["posts"] });
+      navigate(getCommunityPostPath(data.id));
+    },
+  });
+
+  const updatePostMutation = useMutation({
+    mutationFn: () =>
+      callAuthenticated(
+        (token) =>
+          updatePost(token, Number(postId), {
+            content: trimmedContent,
+            category,
+            attachmentIds: [
+              ...(post?.attachments.map((a) => a.id) ?? []),
+              ...newAttachments
+                .filter((a) => a.attachmentId !== null)
+                .map((a) => a.attachmentId!),
+            ],
+          }),
+        navigate,
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["posts"] });
+      navigate(getCommunityPostPath(Number(postId)));
+    },
+  });
+
+  const isPending = createPostMutation.isPending || updatePostMutation.isPending;
 
   useEffect(
     () => () => {
-      imageUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+      localUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
     },
     [],
   );
 
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const remainingCount = Math.max(
-      0,
-      3 - (post?.attachments.length ?? 0) - imageUrlsRef.current.length,
-    );
+    const existingCount =
+      (post?.attachments.length ?? 0) + newAttachments.length;
+    const remainingCount = Math.max(0, 3 - existingCount);
     const files = Array.from(event.target.files ?? []).slice(0, remainingCount);
-    const urls = files.map((image) => URL.createObjectURL(image));
-
-    imageUrlsRef.current = [...imageUrlsRef.current, ...urls];
-    setImageUrls(imageUrlsRef.current);
     event.target.value = "";
+
+    if (files.length === 0) return;
+
+    const entries: NewAttachment[] = files.map((file) => {
+      const key = ++keyCounterRef.current;
+      const localUrl = URL.createObjectURL(file);
+      localUrlsRef.current.push(localUrl);
+      return { key, localUrl, attachmentId: null };
+    });
+
+    setNewAttachments((prev) => [...prev, ...entries]);
+
+    const token = getAccessToken();
+    if (!token) return;
+
+    void Promise.all(
+      entries.map(async (entry, i) => {
+        try {
+          const { attachmentId, presignedUrl } = await beginAttachmentUpload(
+            token,
+          );
+          await fetch(presignedUrl, {
+            method: "PUT",
+            body: files[i],
+            headers: { "Content-Type": files[i].type },
+          });
+          await confirmAttachmentUpload(token, { attachmentId });
+          setNewAttachments((prev) =>
+            prev.map((a) =>
+              a.key === entry.key ? { ...a, attachmentId } : a,
+            ),
+          );
+        } catch {
+          setNewAttachments((prev) => prev.filter((a) => a.key !== entry.key));
+        }
+      }),
+    );
   };
 
   const handleComplete = () => {
-    if (isCompleteDisabled) return;
+    if (isCompleteDisabled || isPending) return;
 
-    navigate(post ? getCommunityPostPath(post.id) : "/community");
+    if (isEdit) {
+      updatePostMutation.mutate();
+    } else {
+      createPostMutation.mutate();
+    }
   };
 
   if (postId && !post) return null;
@@ -187,7 +208,7 @@ const PostWriteContent = ({
         title={isEdit ? "글 수정" : "글 작성"}
         rightType="text"
         rightText={isEdit ? "완료" : "게시"}
-        rightDisabled={isCompleteDisabled}
+        rightDisabled={isCompleteDisabled || isPending}
         onBackClick={() => navigate(-1)}
         onRightClick={handleComplete}
       />

--- a/apps/frontend-user/src/pages/Community/PostWrite.tsx
+++ b/apps/frontend-user/src/pages/Community/PostWrite.tsx
@@ -22,7 +22,6 @@ import {
   confirmAttachmentUpload,
 } from "../../api/api";
 import { callAuthenticated } from "../../api/callAuthenticated";
-import { getAccessToken } from "../../api/tokens";
 import { POST_CATEGORIES } from "../../postCategory";
 
 const COMMUNITY_AUTHOR_NICKNAME = "마음지기";
@@ -38,6 +37,7 @@ type NewAttachment = {
   key: number;
   localUrl: string;
   attachmentId: number | null;
+  uploadFailed?: boolean;
 };
 
 export const PostWritePage = () => {
@@ -53,6 +53,10 @@ export const PostWritePage = () => {
       ),
     enabled: postId !== undefined,
   });
+
+  useEffect(() => {
+    if (postId !== undefined && postQuery.isError) navigate(-1);
+  }, [postId, postQuery.isError, navigate]);
 
   if (postId !== undefined && !postQuery.data) return null;
 
@@ -82,17 +86,18 @@ const PostWriteContent = ({
   const displayNickname = post?.author.nickname ?? COMMUNITY_AUTHOR_NICKNAME;
   const pictures: PictureDto[] = [
     ...(post?.attachments ?? []),
-    ...newAttachments.map((a) => ({ id: a.attachmentId ?? a.key, url: a.localUrl })),
+    ...newAttachments.map((a) => ({ id: a.attachmentId ?? -a.key, url: a.localUrl })),
   ];
   const trimmedContent = content.trim();
-  const hasUploadPending = newAttachments.some((a) => a.attachmentId === null);
+  const hasUploadPending = newAttachments.some((a) => a.attachmentId === null && !a.uploadFailed);
+  const hasUploadFailed = newAttachments.some((a) => a.uploadFailed);
   const isPostUnchanged =
     post !== undefined &&
     category === post.category &&
     trimmedContent === post.content.trim() &&
     newAttachments.length === 0;
   const isCompleteDisabled =
-    !trimmedContent || isPostUnchanged || hasUploadPending;
+    !trimmedContent || isPostUnchanged || hasUploadPending || hasUploadFailed;
 
   const createPostMutation = useMutation({
     mutationFn: () =>
@@ -163,28 +168,34 @@ const PostWriteContent = ({
 
     setNewAttachments((prev) => [...prev, ...entries]);
 
-    const token = getAccessToken();
-    if (!token) return;
-
     void Promise.all(
       entries.map(async (entry, i) => {
         try {
-          const { attachmentId, presignedUrl } = await beginAttachmentUpload(
-            token,
+          const { attachmentId, presignedUrl } = await callAuthenticated(
+            (token) => beginAttachmentUpload(token),
+            navigate,
           );
-          await fetch(presignedUrl, {
+          const uploadResponse = await fetch(presignedUrl, {
             method: "PUT",
             body: files[i],
             headers: { "Content-Type": files[i].type },
           });
-          await confirmAttachmentUpload(token, { attachmentId });
+          if (!uploadResponse.ok) throw new Error("Upload failed");
+          await callAuthenticated(
+            (token) => confirmAttachmentUpload(token, { attachmentId }),
+            navigate,
+          );
           setNewAttachments((prev) =>
             prev.map((a) =>
               a.key === entry.key ? { ...a, attachmentId } : a,
             ),
           );
         } catch {
-          setNewAttachments((prev) => prev.filter((a) => a.key !== entry.key));
+          setNewAttachments((prev) =>
+            prev.map((a) =>
+              a.key === entry.key ? { ...a, uploadFailed: true } : a,
+            ),
+          );
         }
       }),
     );
@@ -238,6 +249,9 @@ const PostWriteContent = ({
           {pictures.length > 0 && (
             <PictureContainer aria-label="첨부 이미지">
               <PictureList pictures={pictures} />
+              {hasUploadFailed && (
+                <UploadError>일부 이미지 업로드에 실패했습니다.</UploadError>
+              )}
             </PictureContainer>
           )}
         </InputWrapper>
@@ -332,4 +346,10 @@ const HiddenInput = styled.input`
 
 const PictureContainer = styled.div`
   padding: 0.625rem 0;
+`;
+
+const UploadError = styled.p`
+  margin-top: 0.5rem;
+  color: ${COLORS.gray.gray500};
+  ${TEXT_STYLE.body.sm};
 `;

--- a/apps/frontend-user/src/pages/Home.tsx
+++ b/apps/frontend-user/src/pages/Home.tsx
@@ -1,1 +1,1 @@
-export const Home = () => {};
+export const Home = () => null;

--- a/apps/frontend-user/src/postCategory.ts
+++ b/apps/frontend-user/src/postCategory.ts
@@ -1,18 +1,19 @@
 import type { PostCategory } from "./type/index";
 
+export const POST_CATEGORY_LABELS: Record<PostCategory, string> = {
+  CONCERN: "고민상담",
+  DIARY: "일상",
+  INQUIRY: "문의",
+  OTHER: "기타",
+};
+
 export const POST_CATEGORIES: ReadonlyArray<{
   value: PostCategory;
   label: string;
-}> = [
-  { value: "CONCERN", label: "고민상담" },
-  { value: "DIARY", label: "일상" },
-  { value: "INQUIRY", label: "문의" },
-  { value: "OTHER", label: "기타" },
-];
-
-export const POST_CATEGORY_LABELS = Object.fromEntries(
-  POST_CATEGORIES.map(({ value, label }) => [value, label]),
-) as Record<PostCategory, string>;
+}> = (Object.keys(POST_CATEGORY_LABELS) as PostCategory[]).map((value) => ({
+  value,
+  label: POST_CATEGORY_LABELS[value],
+}));
 
 export function getPostCategoryLabel(category: PostCategory): string {
   return POST_CATEGORY_LABELS[category];

--- a/apps/frontend-user/src/postCategory.ts
+++ b/apps/frontend-user/src/postCategory.ts
@@ -1,0 +1,19 @@
+import type { PostCategory } from "./type/index";
+
+export const POST_CATEGORIES: ReadonlyArray<{
+  value: PostCategory;
+  label: string;
+}> = [
+  { value: "CONCERN", label: "고민상담" },
+  { value: "DIARY", label: "일상" },
+  { value: "INQUIRY", label: "문의" },
+  { value: "OTHER", label: "기타" },
+];
+
+export const POST_CATEGORY_LABELS = Object.fromEntries(
+  POST_CATEGORIES.map(({ value, label }) => [value, label]),
+) as Record<PostCategory, string>;
+
+export function getPostCategoryLabel(category: PostCategory): string {
+  return POST_CATEGORY_LABELS[category];
+}

--- a/apps/frontend-user/src/type/index.ts
+++ b/apps/frontend-user/src/type/index.ts
@@ -1,34 +1,28 @@
 import type { z } from "zod";
-import { LoginRequestDtoSchema } from "../../../../packages/api-types/src/auth/login";
-import { ResetPasswordRequestDtoSchema } from "../../../../packages/api-types/src/auth/reset-password";
-import { SendMailRequestDtoSchema } from "../../../../packages/api-types/src/auth/send-sign-up-mail";
-import { EmailPasswordResetRequestDtoSchema } from "../../../../packages/api-types/src/auth/send-password-reset-mail";
-import { CompleteSignupRequestDtoSchema } from "../../../../packages/api-types/src/auth/sign-up";
-import { VerifyMailRequestDtoSchema } from "../../../../packages/api-types/src/auth/get-email-token";
-import { AuthorNicknameSchema } from "../../../../packages/api-types/src/common/author";
 import {
   ActiveCommentDtoSchema,
-  AuthorDeletedCommentDtoSchema,
-  DeletedCommentDtoSchema,
-} from "../../../../packages/api-types/src/common/comment";
-import {
   AttachmentDtoSchema,
+  AuthorDeletedCommentDtoSchema,
+  AuthorNicknameSchema,
+  CompleteSignupRequestDtoSchema,
+  CreateDiagnosisRequestDtoSchema,
+  DeletedCommentDtoSchema,
+  EmailPasswordResetRequestDtoSchema,
+  LoginRequestDtoSchema,
+  MissionAssignmentDtoSchema,
   PostCategorySchema,
   PostContentSchema,
   PostDtoSchema,
   PostWithCommentsSchema,
-} from "../../../../packages/api-types/src/common/post";
-import { ResourceDtoSchema } from "../../../../packages/api-types/src/common/resource";
-import {
-  MissionAssignmentDtoSchema,
+  ResetPasswordRequestDtoSchema,
+  ResourceDtoSchema,
+  SendMailRequestDtoSchema,
   SimplifiedMissionSchema,
-} from "../../../../packages/api-types/src/common/mission";
-import {
+  UpdateCurrentUserRequestDtoSchema,
   UserDtoSchema,
   UserProfileDtoSchema,
-} from "../../../../packages/api-types/src/common/user";
-import { CreateDiagnosisRequestDtoSchema } from "../../../../packages/api-types/src/diagnoses/create-diagnosis";
-import { UpdateCurrentUserRequestDtoSchema } from "../../../../packages/api-types/src/users/update-current-profile";
+  VerifyMailRequestDtoSchema,
+} from "@mindseed/api-types";
 
 export { AuthorNicknameSchema };
 export {
@@ -53,7 +47,7 @@ export {
   VerifyMailRequestDtoSchema,
 };
 export { UpdateCurrentUserRequestDtoSchema };
-export { PasswordSchema } from "../../../../packages/api-types/src/common/user";
+export { PasswordSchema } from "@mindseed/api-types";
 
 export const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 

--- a/apps/frontend-user/src/type/index.ts
+++ b/apps/frontend-user/src/type/index.ts
@@ -55,6 +55,8 @@ export {
 export { UpdateCurrentUserRequestDtoSchema };
 export { PasswordSchema } from "../../../../packages/api-types/src/common/user";
 
+export const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export type PictureDto = z.infer<typeof AttachmentDtoSchema>;
 export type CommunityPostFixture = z.input<typeof PostWithCommentsSchema>;
 export type CommunityPost = z.infer<typeof PostWithCommentsSchema>;

--- a/apps/frontend-user/src/type/index.ts
+++ b/apps/frontend-user/src/type/index.ts
@@ -49,8 +49,6 @@ export {
 export { UpdateCurrentUserRequestDtoSchema };
 export { PasswordSchema } from "@mindseed/api-types";
 
-export const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
 export type PictureDto = z.infer<typeof AttachmentDtoSchema>;
 export type CommunityPostFixture = z.input<typeof PostWithCommentsSchema>;
 export type CommunityPost = z.infer<typeof PostWithCommentsSchema>;

--- a/packages/api-types/src/common/comment.ts
+++ b/packages/api-types/src/common/comment.ts
@@ -1,7 +1,6 @@
 import z from "zod";
 import { dateSerializerCodec } from "./codecs";
 import { AuthorDtoSchema } from "./author";
-import { PostDtoSchema } from "./post";
 
 export const CommentContentSchema = z.string().min(1).max(200);
 
@@ -12,6 +11,7 @@ export const ActiveCommentDtoSchema = z.object({
   id: z.int(),
   content: CommentContentSchema,
   author: AuthorDtoSchema,
+  isOwner: z.boolean(),
   createdAt: dateSerializerCodec,
   updatedAt: dateSerializerCodec,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,10 +43,10 @@ importers:
         version: 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)
       '@nestjs/schedule':
         specifier: ^6.1.1
-        version: 6.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)
+        version: 6.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2))
       '@nestjs/typeorm':
         specifier: ^11.0.0
-        version: 11.0.0(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))
+        version: 11.0.0(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -98,7 +98,7 @@ importers:
         version: 11.0.9(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.0.1
-        version: 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@nestjs/platform-express@11.1.16)
+        version: 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16))
       '@types/bcrypt':
         specifier: ^6.0.0
         version: 6.0.0
@@ -171,6 +171,9 @@ importers:
       '@mindseed/api-types':
         specifier: workspace:*
         version: link:../../packages/api-types
+      '@tanstack/react-query':
+        specifier: ^5.101.4
+        version: 5.101.4(react@19.2.4)
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
@@ -1310,79 +1313,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1642,6 +1632,14 @@ packages:
   '@sqltools/formatter@1.2.5':
     resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
 
+  '@tanstack/query-core@5.101.4':
+    resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
+
+  '@tanstack/react-query@5.101.4':
+    resolution: {integrity: sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -1887,49 +1885,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -6026,7 +6016,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/schedule@6.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)':
+  '@nestjs/schedule@6.1.1(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2))':
     dependencies:
       '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -6043,7 +6033,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@nestjs/platform-express@11.1.16)':
+  '@nestjs/testing@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16))':
     dependencies:
       '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -6051,7 +6041,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)
 
-  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))':
+  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))':
     dependencies:
       '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.16)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -6501,6 +6491,13 @@ snapshots:
       tslib: 2.8.1
 
   '@sqltools/formatter@1.2.5': {}
+
+  '@tanstack/query-core@5.101.4': {}
+
+  '@tanstack/react-query@5.101.4(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.101.4
+      react: 19.2.4
 
   '@tokenizer/inflate@0.4.1':
     dependencies:


### PR DESCRIPTION
## 요약

- Closes #142 
- `frontend-user`
  - 사용자 및 커뮤니티 페이지에 API 연동을 추가하였습니다.
  - 아직 올라오지 않은 페이지 라우팅은 삭제하였습니다.
- `backend` 및 `api-types`: 기능 구현을 위해 글 작성자 여부 필드를 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community posts, comments, likes, reports, creation, and editing now use live backend data.
  * Added image uploads with previews, upload status, and a three-image limit.
  * Added report dialogs for posts and comments.
  * Added category labels and category-based filtering.
  * Authentication flows now support sign-up, login, password reset, token refresh, and clearer error messages.

* **Bug Fixes**
  * Comment ownership is now identified correctly.
  * Improved authentication redirects and session recovery.
  * Standardized category values and labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->